### PR TITLE
ANALYTICS_DEBUG_MODE logging turned On in Debug builds, Off in Release builds

### DIFF
--- a/Analytics.m
+++ b/Analytics.m
@@ -3,8 +3,9 @@
 
 #import "Analytics.h"
 
-// Uncomment this line to turn on debug logging
+#ifdef DEBUG
 #define ANALYTICS_DEBUG_MODE
+#endif
 
 #ifdef ANALYTICS_DEBUG_MODE
 #define AnalyticsDebugLog(...) NSLog(__VA_ARGS__)


### PR DESCRIPTION
- Switch to turn ANALYTICS_DEBUG_MODE logging On in Debug builds, Off in Release builds
- I believe you wanted logging to be disabled by default, and for the user to manually uncomment the line... 9410c03 enabled it by default on master.
