### PR TITLE
Fixed literals syntax for iOS 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /Examples/CocoaPodsExample/Podfile.lock
 /Examples/DirectIncludeExample/Analytics.framework
 *.xccheckout
+/Build
+/DerivedData

--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 
 /* Begin PBXBuildFile section */
 		18E86AF9AC7C4CB494AEA208 /* libPods-AnalyticsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 23CD79ED9C3E478C83CB7A34 /* libPods-AnalyticsTests.a */; };
+		2822D5FF17E26C9E005B2B7F /* NSContainer+Subscripting.h in Headers */ = {isa = PBXBuildFile; fileRef = 2822D5FD17E26C9E005B2B7F /* NSContainer+Subscripting.h */; };
+		2822D60017E26C9E005B2B7F /* NSContainer+Subscripting.m in Sources */ = {isa = PBXBuildFile; fileRef = 2822D5FE17E26C9E005B2B7F /* NSContainer+Subscripting.m */; };
 		B8A1B15E08994855871D1685 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 70B38155D048462482A91850 /* libPods.a */; };
 		EA25892317C6979D000CEF61 /* Analytics.h in Headers */ = {isa = PBXBuildFile; fileRef = F7200B7B17659B2F003F3138 /* Analytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA3B4CC717C8900A00233EA9 /* SegmentioTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3B4CC617C8900A00233EA9 /* SegmentioTests.m */; };
@@ -71,7 +73,7 @@
 		EACB4DEB17C0BB3100624129 /* AnalyticsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EACB4DD117C0BB3100624129 /* AnalyticsUtils.m */; };
 		EAD415C717C9B72D00EB0490 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA722AF217C87BB00016E8B0 /* SenTestingKit.framework */; };
 		F7200B7717659B2F003F3138 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7200B7617659B2F003F3138 /* Foundation.framework */; };
-		F7200B7E17659B2F003F3138 /* Analytics.m in Sources */ = {isa = PBXBuildFile; fileRef = F7200B7D17659B2F003F3138 /* Analytics.m */; };
+		F7200B7E17659B2F003F3138 /* Analytics.m in Sources */ = {isa = PBXBuildFile; fileRef = F7200B7D17659B2F003F3138 /* Analytics.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		F78D29FA1765B382000B937E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F78D29F91765B382000B937E /* UIKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -88,6 +90,8 @@
 /* Begin PBXFileReference section */
 		1292362745B3499F9F8849DB /* Pods-AnalyticsTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsTests.xcconfig"; path = "Pods/Pods-AnalyticsTests.xcconfig"; sourceTree = SOURCE_ROOT; };
 		23CD79ED9C3E478C83CB7A34 /* libPods-AnalyticsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AnalyticsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2822D5FD17E26C9E005B2B7F /* NSContainer+Subscripting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSContainer+Subscripting.h"; sourceTree = "<group>"; };
+		2822D5FE17E26C9E005B2B7F /* NSContainer+Subscripting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSContainer+Subscripting.m"; sourceTree = "<group>"; };
 		70B38155D048462482A91850 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D0FCA5DB8CF4351BA2EC04C /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
 		EA3B4CC617C8900A00233EA9 /* SegmentioTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SegmentioTests.m; sourceTree = "<group>"; };
@@ -376,6 +380,8 @@
 		F7200B7917659B2F003F3138 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				2822D5FD17E26C9E005B2B7F /* NSContainer+Subscripting.h */,
+				2822D5FE17E26C9E005B2B7F /* NSContainer+Subscripting.m */,
 				F7200B7A17659B2F003F3138 /* Analytics-Prefix.pch */,
 			);
 			name = "Supporting Files";
@@ -397,6 +403,7 @@
 				EACB4DDA17C0BB3100624129 /* CountlyProvider.h in Headers */,
 				EACB4DDC17C0BB3100624129 /* FlurryProvider.h in Headers */,
 				EACB4DDE17C0BB3100624129 /* GoogleAnalyticsProvider.h in Headers */,
+				2822D5FF17E26C9E005B2B7F /* NSContainer+Subscripting.h in Headers */,
 				EACB4DE017C0BB3100624129 /* KISSmetricsProvider.h in Headers */,
 				EACB4DE217C0BB3100624129 /* LocalyticsProvider.h in Headers */,
 				EACB4DE417C0BB3100624129 /* MixpanelProvider.h in Headers */,
@@ -610,6 +617,7 @@
 				EACB4DD317C0BB3100624129 /* AmplitudeProvider.m in Sources */,
 				EACB4DD717C0BB3100624129 /* BugsnagProvider.m in Sources */,
 				EACB4DD917C0BB3100624129 /* ChartbeatProvider.m in Sources */,
+				2822D60017E26C9E005B2B7F /* NSContainer+Subscripting.m in Sources */,
 				EACB4DDB17C0BB3100624129 /* CountlyProvider.m in Sources */,
 				EACB4DDD17C0BB3100624129 /* FlurryProvider.m in Sources */,
 				EACB4DDF17C0BB3100624129 /* GoogleAnalyticsProvider.m in Sources */,

--- a/Analytics/Analytics-Prefix.pch
+++ b/Analytics/Analytics-Prefix.pch
@@ -4,4 +4,5 @@
 
 #ifdef __OBJC__
     #import <Foundation/Foundation.h>
+    #import "NSContainer+Subscripting.h"
 #endif

--- a/Analytics/NSContainer+Subscripting.h
+++ b/Analytics/NSContainer+Subscripting.h
@@ -1,0 +1,28 @@
+//
+//  NSContainer+Subscripting.h
+//
+//  Created by Markus Emrich on 10.08.12.
+//  Copyright 2012 nxtbgthng. All rights reserved.
+//
+
+#if !defined(__IPHONE_6_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
+
+#import "NSContainer+Subscripting.h"
+
+@interface NSArray (Subscripting)
+- (id)objectAtIndexedSubscript:(NSInteger)index;
+@end
+
+@interface NSMutableArray (MutableSubscripting)
+- (void)setObject:(id)anObject atIndexedSubscript:(NSUInteger)index;
+@end
+
+@interface NSDictionary (Subscripting)
+- (id)objectForKeyedSubscript:(id)key;
+@end
+
+@interface NSMutableDictionary (MutableSubscripting)
+- (void)setObject:(id)object forKeyedSubscript:(id)key;
+@end
+
+#endif

--- a/Analytics/NSContainer+Subscripting.m
+++ b/Analytics/NSContainer+Subscripting.m
@@ -1,0 +1,36 @@
+//
+//  NSContainer+Subscripting.m
+//
+//  Created by Markus Emrich on 10.08.12.
+//  Copyright 2012 nxtbgthng. All rights reserved.
+//
+
+#if !defined(__IPHONE_6_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
+
+#import "NSContainer+Subscripting.h"
+
+@implementation NSArray (Subscripting)
+- (id)objectAtIndexedSubscript:(NSInteger)index {
+    return [self objectAtIndex:index];
+}
+@end
+
+@implementation NSMutableArray (MutableSubscripting)
+- (void)setObject:(id)anObject atIndexedSubscript:(NSUInteger)index {
+    [self insertObject:anObject atIndex:index];
+}
+@end
+
+@implementation NSDictionary (Subscripting)
+-(id)objectForKeyedSubscript:(id)key {
+    return [self objectForKey: key];
+}
+@end
+
+@implementation NSMutableDictionary (MutableSubscripting)
+- (void)setObject:(id)object forKeyedSubscript:(id)key {
+    [self setObject:object forKey: key];
+}
+@end
+
+#endif

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,84 @@
+PODS:
+  - Amplitude-iOS (1.0.1)
+  - BlocksKit (1.8.3):
+    - libffi
+  - Bugsnag (2.2.3.fork)
+  - Chartbeat (0.0.1)
+  - CLToolkit/Core (0.0.5):
+    - BlocksKit
+    - ConciseKit
+    - ISO8601DateFormatter
+    - NSLogger
+    - ReactiveCocoa
+  - CLToolkit/Testing (0.0.5):
+    - CLToolkit/Core
+    - Kiwi
+  - ConciseKit (0.1.2)
+  - Countly (1.0.0)
+  - FlurrySDK (4.2.3)
+  - GoogleAnalytics-iOS-SDK (3.0)
+  - ISO8601DateFormatter (0.6)
+  - JRSwizzle (1.0)
+  - KISSmetrics (1.1.3)
+  - Kiwi (2.2.1):
+    - Kiwi/ARC
+    - Kiwi/NonARC
+  - Kiwi/ARC (2.2.1)
+  - Kiwi/NonARC (2.2.1)
+  - libextobjc/EXTConcreteProtocol (0.3):
+    - libextobjc/RuntimeExtensions
+  - libextobjc/EXTKeyPathCoding (0.3):
+    - libextobjc/RuntimeExtensions
+  - libextobjc/EXTScope (0.3):
+    - libextobjc/RuntimeExtensions
+  - libextobjc/RuntimeExtensions (0.3)
+  - libffi (3.0.13)
+  - Localytics-iOS-Client (2.17.0)
+  - Mixpanel (2.0.1)
+  - NSLogger (1.1)
+  - ReactiveCocoa (1.9.7):
+    - ReactiveCocoa/Core
+    - ReactiveCocoa/RACExtensions
+  - ReactiveCocoa/Core (1.9.7):
+    - JRSwizzle (~> 1.0)
+    - libextobjc/EXTConcreteProtocol (~> 0.3.0)
+    - libextobjc/EXTKeyPathCoding (~> 0.3.0)
+    - libextobjc/EXTScope (~> 0.3.0)
+  - ReactiveCocoa/RACExtensions (1.9.7):
+    - ReactiveCocoa/Core
+
+DEPENDENCIES:
+  - Amplitude-iOS (~> 1.0.1)
+  - Bugsnag (= 2.2.3.fork)
+  - Chartbeat (~> 0.0.1)
+  - CLToolkit/Testing
+  - Countly (~> 1.0.0)
+  - FlurrySDK (~> 4.2.3)
+  - GoogleAnalytics-iOS-SDK (~> 3.0)
+  - KISSmetrics (~> 1.1.3)
+  - Kiwi
+  - Localytics-iOS-Client (~> 2.17.0)
+  - Mixpanel (~> 2.0.0)
+
+SPEC CHECKSUMS:
+  Amplitude-iOS: 165d4a619a5a40ea74de412d7a33a2e4f3fdd0f9
+  BlocksKit: 27257f9cbbec0ea98c80ba83cc2ea7111ae62eb2
+  Bugsnag: 26ef4c366f9f756e84fb268b04e082df2647993f
+  Chartbeat: 0f2772641ee26e87af8fc93d8f14c5479e44a7ec
+  CLToolkit: bce707420abb7577b852d6a34096951ea3077d9e
+  ConciseKit: 1e086a66d098ba160ca5faa86458a0431b280b30
+  Countly: c9728abbbeffc3250d1ab8ba17b417938119d218
+  FlurrySDK: 20b3fd669eeafd005ca8ff65a1406d1befbc8031
+  GoogleAnalytics-iOS-SDK: f8d5faf4862b679667be0c270531a189572275d1
+  ISO8601DateFormatter: 077ce9d8cfba171bc1ced6cba0d2ae4aefab7619
+  JRSwizzle: 6242ff38485d870fc2636899048ee1ab883ae587
+  KISSmetrics: b729eba7a66a523f829e801fa0756c3ff358e58a
+  Kiwi: e6524ba0eaa1b28af7af146bdee5314b32aa3edb
+  libextobjc: 820a79dbbbc498611e04fffd07d2d52a5588e7ac
+  libffi: 64ef39353e747bb2b25e1026afd96a157bf9231c
+  Localytics-iOS-Client: 6f67f3d23eb5ca7958af5155a2c570b641d53417
+  Mixpanel: e0311534e33c62dd7aa1486d71b499adbfcf1a40
+  NSLogger: 4567fef08d0db18a89cce91b2053823fc0950738
+  ReactiveCocoa: b680ab9b8c64a3c9956492f0702006ea541164fc
+
+COCOAPODS: 0.24.0


### PR DESCRIPTION
I'm using Analytics in a iOS5+ project and when running the app on iOS5 it crashes with 

```
[__NSCFDictionary setObject:forKeyedSubscript:]: unrecognized selector sent to instance 0x8a7f910
```

To replicate just run the test on the Analytics project on iOS5 simulator.
This PR uses code from https://gist.github.com/jaydee3/3314686
