### PR TITLE
Updated Amplitude to 2.0.0

### DIFF
--- a/Analytics/Providers/Amplitude/AmplitudeProvider.m
+++ b/Analytics/Providers/Amplitude/AmplitudeProvider.m
@@ -46,12 +46,12 @@
 - (void)identify:(NSString *)userId traits:(NSDictionary *)traits options:(NSDictionary *)options
 {
     [Amplitude setUserId:userId];
-    [Amplitude setGlobalUserProperties:traits];
+    [Amplitude setUserProperties:traits];
 }
 
 - (void)track:(NSString *)event properties:(NSDictionary *)properties options:(NSDictionary *)options
 {
-    [Amplitude logEvent:event withCustomProperties:properties];
+    [Amplitude logEvent:event withEventProperties:properties];
 
     // Track any revenue.
     NSNumber *revenue = [AnalyticsProvider extractRevenue:properties];

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,6 @@
 link_with 'Analytics'
 
-pod 'Amplitude-iOS', '~> 1.0.2'
+pod 'Amplitude-iOS', '~> 2.0.0'
 pod 'Bugsnag', '3.1.0.fork'
 pod 'Countly', '~> 1.0.0'
 pod 'CrittercismSDK', '~> 4.3.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Amplitude-iOS (1.0.2)
+  - Amplitude-iOS (2.0.0)
   - Bugsnag (3.1.0.fork)
   - Countly (1.0.0)
   - CrittercismSDK (4.3.1)
@@ -17,7 +17,7 @@ PODS:
   - Tapstream (2.6)
 
 DEPENDENCIES:
-  - Amplitude-iOS (~> 1.0.2)
+  - Amplitude-iOS (~> 2.0.0)
   - Bugsnag (= 3.1.0.fork)
   - Countly (~> 1.0.0)
   - CrittercismSDK (~> 4.3.1)


### PR DESCRIPTION
Pointing to the new version of Amplitude-iOS. Updated method calls in providers.

Did not modify Podfile.lock SPEC CHECKSUMS for the Amplitude library. Was unclear how the checksum was computed.
