### PR TITLE
Set traits to individual events instead of all events in a batch

### DIFF
--- a/Analytics/Providers/Segmentio/SegmentioProvider.m
+++ b/Analytics/Providers/Segmentio/SegmentioProvider.m
@@ -266,7 +266,7 @@ static NSString *GetSessionID(BOOL reset) {
     serverOptions[@"providers"] = providersDict;
     serverOptions[@"library"] = @"analytics-ios";
     serverOptions[@"library-version"] = NSStringize(ANALYTICS_VERSION);
-    serverOptions[@"traits"] = _traits;
+    serverOptions[@"traits"] = [_traits copy];
     for(id key in _deviceInformation) {
         serverOptions[key] = [_deviceInformation objectForKey:key];
     }


### PR DESCRIPTION
The patch fixes an issue with incorrect traits setting.
Steps to reproduce an issue:
- Set some traits.
- Track an event.
- Change traits (for example, add a user email).
- Track another event. **Important**: events should be in the same batch.
- Observe batched events

**Actual result**: both events have the same traits (with last changes applied).
**Expected result**: events have individual traits in a batch.
