### PR TITLE
Add QC measurement header to public headers

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		7E94C0F018932A5B004BD132 /* KWBlockMatchEvaluator.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E94C0EF18932A5B004BD132 /* KWBlockMatchEvaluator.m */; };
 		7EA1CA851898033000DC8637 /* KWNotificationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EA1CA841898033000DC8637 /* KWNotificationMatcher.m */; };
 		B8A1B15E08994855871D1685 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 70B38155D048462482A91850 /* libPods.a */; };
+		C97697CB190EF63F005C2D5E /* QuantcastMeasurement.h in Headers */ = {isa = PBXBuildFile; fileRef = C97697CA190EF63F005C2D5E /* QuantcastMeasurement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9BC0EF7190F03F500557AAC /* QuantcastOptOutDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = C9BC0EF6190F03F500557AAC /* QuantcastOptOutDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D31C8F7E18A2D83700DA22A6 /* MPNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = D31C8F7D18A2D83700DA22A6 /* MPNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D331BCED185BFAA1007CB22F /* MPSurvey.h in Headers */ = {isa = PBXBuildFile; fileRef = D331BCEC185BFAA1007CB22F /* MPSurvey.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D331BCF2185BFF49007CB22F /* CRFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = D331BCF0185BFF49007CB22F /* CRFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -142,6 +144,8 @@
 		7EA1CA831898033000DC8637 /* KWNotificationMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KWNotificationMatcher.h; sourceTree = "<group>"; };
 		7EA1CA841898033000DC8637 /* KWNotificationMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KWNotificationMatcher.m; sourceTree = "<group>"; };
 		8D0FCA5DB8CF4351BA2EC04C /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
+		C97697CA190EF63F005C2D5E /* QuantcastMeasurement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = QuantcastMeasurement.h; path = "Pods/Quantcast-Measure/Quantcast-iOS-Measurement/QuantcastMeasurement.h"; sourceTree = "<group>"; };
+		C9BC0EF6190F03F500557AAC /* QuantcastOptOutDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = QuantcastOptOutDelegate.h; path = "Pods/Quantcast-Measure/Quantcast-iOS-Measurement/QuantcastOptOutDelegate.h"; sourceTree = "<group>"; };
 		D309DBF218A2BD2900BA9F31 /* libFlurry_4.3.1.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFlurry_4.3.1.a; path = Pods/FlurrySDK/Flurry/libFlurry_4.3.1.a; sourceTree = "<group>"; };
 		D31C8F7D18A2D83700DA22A6 /* MPNotification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MPNotification.h; path = Pods/Mixpanel/Mixpanel/MPNotification.h; sourceTree = "<group>"; };
 		D331BCEC185BFAA1007CB22F /* MPSurvey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MPSurvey.h; path = Pods/Mixpanel/Mixpanel/MPSurvey.h; sourceTree = "<group>"; };
@@ -347,6 +351,8 @@
 				D331BCF8185C2DC4007CB22F /* GAILogger.h */,
 				D331BCF9185C2DC4007CB22F /* GAITrackedViewController.h */,
 				D331BCFA185C2DC4007CB22F /* GAITracker.h */,
+				C9BC0EF6190F03F500557AAC /* QuantcastOptOutDelegate.h */,
+				C97697CA190EF63F005C2D5E /* QuantcastMeasurement.h */,
 				D3C07FBE185954D000649011 /* Bugsnag.h */,
 				D371F331185942DE0053337D /* GAI.h */,
 				D371F32F185942C90053337D /* Flurry.h */,
@@ -584,6 +590,8 @@
 				D331BD07185FDDEA007CB22F /* BugsnagDictionary.h in Headers */,
 				D331BD08185FDDEA007CB22F /* BugsnagEvent.h in Headers */,
 				D331BD09185FDDEA007CB22F /* BugsnagLogger.h in Headers */,
+				C97697CB190EF63F005C2D5E /* QuantcastMeasurement.h in Headers */,
+				C9BC0EF7190F03F500557AAC /* QuantcastOptOutDelegate.h in Headers */,
 				D331BD131860EA9A007CB22F /* TapstreamProvider.h in Headers */,
 				D331BD191860F5D4007CB22F /* TSAppEventSourceImpl.h in Headers */,
 				D331BD1A1860F5D4007CB22F /* TSCoreListenerImpl.h in Headers */,


### PR DESCRIPTION
Our app needs to be able to call `[[QuantcastMeasurement sharedInstance] displayUserPrivacyDialogOver:self withDelegate:nil];` to let the user opt out of Quantcast's measurement platform
