### PR TITLE
Changed AsAdvertisingManager class reference to anonymous class. 

### DIFF
--- a/Analytics/Integrations/Segmentio/SEGSegmentioIntegration.m
+++ b/Analytics/Integrations/Segmentio/SEGSegmentioIntegration.m
@@ -20,6 +20,8 @@ NSString *const SEGSegmentioDidSendRequestNotification = @"SegmentioDidSendReque
 NSString *const SEGSegmentioRequestDidSucceedNotification = @"SegmentioRequestDidSucceed";
 NSString *const SEGSegmentioRequestDidFailNotification = @"SegmentioRequestDidFail";
 
+NSString *const SEGAdvertisingClassIdentifier = @"ASIdentifierManager";
+
 static NSString *GenerateUUIDString() {
   CFUUIDRef theUUID = CFUUIDCreate(NULL);
   NSString *UUIDString = (__bridge_transfer NSString *)CFUUIDCreateString(NULL, theUUID);
@@ -51,8 +53,9 @@ static NSString *GetDeviceModel() {
 }
 
 static NSString *GetIdForAdvertiser() {
-  if ([ASIdentifierManager class]) {
-    return [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+  Class advertisingClass = NSClassFromString(SEGAdvertisingClassIdentifier);
+  if (advertisingClass) {
+    return [[[advertisingClass sharedManager] advertisingIdentifier] UUIDString];
   } else {
     return nil;
   }
@@ -86,8 +89,10 @@ static NSDictionary *BuildStaticContext() {
     dict[@"manufacturer"] = @"Apple";
     dict[@"model"] = GetDeviceModel();
     dict[@"idfv"] = [[device identifierForVendor] UUIDString];
-    if ([ASIdentifierManager class])
-      dict[@"adTrackingEnabled"] = @([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]);
+    Class advertisingClass = NSClassFromString(SEGAdvertisingClassIdentifier);
+    if (advertisingClass) {
+      dict[@"adTrackingEnabled"] = @([[advertisingClass sharedManager] isAdvertisingTrackingEnabled]);
+    }
     NSString *idfa = GetIdForAdvertiser();
     if (idfa.length) dict[@"idfa"] = idfa;
     dict;


### PR DESCRIPTION
Even with weak linking, the AdSupport.framework is included when frameworks are linked. I made a demo project to illustrate what's going on here: https://github.com/distefam/AdSupportDemo
