### PR TITLE
Fix warnings

### DIFF
--- a/Analytics/SEGAnalyticsUtils.h
+++ b/Analytics/SEGAnalyticsUtils.h
@@ -24,6 +24,6 @@ void SEGLog(NSString *format, ...);
 
 NSDictionary *SEGCoerceDictionary(NSDictionary *dict);
 
-NSString *SEGIDFA();
+NSString *SEGIDFA(void);
 
 NSString *SEGEventNameForScreenTitle(NSString *title);


### PR DESCRIPTION
Allows the project to build when treating "Missing Newline At End Of File" and "Missing Function Prototypes" as errors.
