### PR TITLE
Fix "unreachable code" warning.

### DIFF
--- a/Analytics/Helpers/SEGBluetooth.m
+++ b/Analytics/Helpers/SEGBluetooth.m
@@ -27,12 +27,7 @@ const NSString *SEGCentralManagerClass = @"CBCentralManager";
   if (!(self = [super init])) return nil;
 
   _queue = dispatch_queue_create("io.segment.bluetooth.queue", NULL);
-
-  if (&CBCentralManagerOptionShowPowerAlertKey != NULL) {
-    _manager = [[centralManager alloc] initWithDelegate:self queue:_queue options:@{ CBCentralManagerOptionShowPowerAlertKey: @NO }];
-  } else {
-    _manager = [[centralManager alloc] initWithDelegate:self queue:_queue];
-  }
+  _manager = [[centralManager alloc] initWithDelegate:self queue:_queue options:@{ CBCentralManagerOptionShowPowerAlertKey: @NO }];
 
   return self;
 }


### PR DESCRIPTION
Allows the project to build when treating "Unreachable Code" as error.

I'm not so sure about that fix since I don't know exactly the role of this check " if (&CBCentralManagerOptionShowPowerAlertKey != NULL) {".
