### PR TITLE
Removing ad support reference

### DIFF
--- a/Analytics/SEGAnalyticsUtils.m
+++ b/Analytics/SEGAnalyticsUtils.m
@@ -2,7 +2,6 @@
 // Copyright (c) 2014 Segment.io. All rights reserved.
 
 #import "SEGAnalyticsUtils.h"
-#import <AdSupport/ASIdentifierManager.h>
 
 static BOOL kAnalyticsLoggerShowLogs = NO;
 


### PR DESCRIPTION
This reference caused my app to be flagged as using the IDFA. This forces you to choose why you are using the IDFA (I wasn't) when submitting to the app store.