### PR TITLE
Update Tapstream version

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -92,7 +92,7 @@
       "name": "Tapstream",
       "dependencies": [{
         "name": "Tapstream",
-        "version": "2.8.1"
+        "version": "2.8.3"
       }]
     },
     {


### PR DESCRIPTION
This should resolve https://github.com/segmentio/analytics-ios/issues/221

Not sure if there are any additional steps necessary for this version number change to get applied, like running a script or something.
