### PR TITLE
Properly cast objc_msgSend calls

### DIFF
--- a/Analytics/Integrations/Flurry/SEGFlurryIntegration.m
+++ b/Analytics/Integrations/Flurry/SEGFlurryIntegration.m
@@ -88,7 +88,7 @@
                         ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
                         ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
   // cocoapods validation cant find +[Flurry setPushToken:]
-  objc_msgSend(Flurry.class, NSSelectorFromString(@"setPushToken:"), hexToken);
+  ((void(*)(Class, SEL, NSString *))objc_msgSend)(Flurry.class, NSSelectorFromString(@"setPushToken:"), hexToken);
 }
 
 @end


### PR DESCRIPTION
See 2014 WWDC Session 417. If not casted, the compiler will complains with `Too many arguments to function call, expected 0, have 3`.