### PR TITLE
Add location to flurry

### DIFF
--- a/Analytics/Integrations/Flurry/SEGFlurryIntegration.m
+++ b/Analytics/Integrations/Flurry/SEGFlurryIntegration.m
@@ -62,6 +62,16 @@
   if (age) {
     [Flurry setAge:[age intValue]];
   }
+  
+  NSDictionary *location = [traits objectForKey:@"location"];
+  
+  if (location) {
+    float latitude = [[location objectForKey:@"latitude"] floatValue];
+    float longitude = [[location objectForKey:@"longitude"] floatValue];
+    float horizontalAccuracy = [[location objectForKey:@"horizontalAccuracy"] floatValue];
+    float verticalAccuracy = [[location objectForKey:@"verticalAccuracy"] floatValue];
+    [Flurry setLatitude:latitude longitude:longitude horizontalAccuracy:horizontalAccuracy verticalAccuracy:verticalAccuracy];
+  }
 }
 
 - (void)track:(NSString *)event properties:(NSDictionary *)properties options:(NSDictionary *)options {


### PR DESCRIPTION
@f2prateek made the same fix to flurry to highlight some ways that https://github.com/segmentio/analytics-ios/pull/250 could have implemented a bit better.

for one we didn't need a separate method to set the default value, since if there is no object for say latitude then that value will be nil, and when any message is sent to nil it's also nil aka 0. kind of an objc behavior thing that can useful to know. 

but let's say the default was something other than 0, another way to do a default like that is `[location objectForKey:@"longitude"] ?: 4;`. where 4 would be the default.

we didn't need to add to this method: 
https://github.com/segmentio/analytics-ios/pull/250#discussion-diff-24203107 but if we did you would have wanted to write it as:

``` objective-c
- (float)floatFromDictionary:(NSDictionary *)dictionary key:(NSString *)key default:(NSNumber *)default {  
// ...
}
```
that way when you called it would have looked like:

``` objective-c 
[self floatFromDictionary:location key:@"latitude" default:0];
```

rather than 

``` objective-c
[self floatForKey:location :@"horizontalAccuracy" :0]
```

notice how in my example, the params are named.