### PR TITLE
Sets the segment tracker always as default

### DIFF
--- a/Analytics/Integrations/GoogleAnalytics/SEGGoogleAnalyticsIntegration.m
+++ b/Analytics/Integrations/GoogleAnalytics/SEGGoogleAnalyticsIntegration.m
@@ -43,7 +43,7 @@
     }
     // Require setup with the trackingId.
     NSString *trackingId = [self.settings objectForKey:@"mobileTrackingId"];
-    [[GAI sharedInstance] trackerWithTrackingId:trackingId];
+    [[GAI sharedInstance] setDefaultTracker:[[GAI sharedInstance] trackerWithTrackingId:trackingId]];
 
     // Optionally turn on uncaught exception tracking.
     NSString *reportUncaughtExceptions = [self.settings objectForKey:@"reportUncaughtExceptions"];


### PR DESCRIPTION
Hi,
I was having trouble using segment as app tracker and GA as [global tracker](https://segment.com/docs/integrations/google-analytics/#multiple-trackers) (multiple GA tracker), because when I set my GA tracker it is set as default and segment wasn't able to track anymore as it uses defaultTracker. 
So I changed this line so the segment tracker will always be the [default](https://developers.google.com/analytics/devguides/collection/ios/v3/advanced#default-tracker), so Segment keeps working and I can yet access my tracker by its ID.

I just changed that file without changing anything else because I don't know your standard for releasing a new version.

Hope it helps, 
Lucas Martins - [ckl.io](ckl.io)

ps. It is a different solution for Pull #272 
