### PR TITLE
Explicitly check if selector exists

### DIFF
--- a/Analytics/Helpers/SEGBluetooth.m
+++ b/Analytics/Helpers/SEGBluetooth.m
@@ -28,10 +28,10 @@ const NSString *SEGCentralManagerClass = @"CBCentralManager";
 
   _queue = dispatch_queue_create("io.segment.bluetooth.queue", NULL);
 
-  // Reading the address inline fails on iOS 6, must use a temporary
-  // variable to compare.
+  // Check if we can use newer CoreBluetooth functions
   NSInteger addr = &CBCentralManagerOptionShowPowerAlertKey;
-  if (addr != 0) {
+  BOOL hasOptions = [centralManager instancesRespondToSelector:@selector(initWithDelegate:queue:options:)];
+  if (hasOptions && addr != 0) {
     _manager = [[centralManager alloc] initWithDelegate:self queue:_queue options:@{ CBCentralManagerOptionShowPowerAlertKey: @NO }];
   } else {
     _manager = [[centralManager alloc] initWithDelegate:self queue:_queue];


### PR DESCRIPTION
Simply checking the symbol address was not sufficient on iOS6.