### PR TITLE
Move push registration to start method

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -222,6 +222,8 @@
 		32F6381C1A8134A600C65643 /* SEGKahunaIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F6381A1A8134A600C65643 /* SEGKahunaIntegration.m */; };
 		32F6381D1A8134A600C65643 /* SEGKahunaIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 32F6381A1A8134A600C65643 /* SEGKahunaIntegration.m */; };
 		6182B863DB2D44D1B463AE3B /* libPods-iOS Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 24AE4A015CBF4E95B18D10A7 /* libPods-iOS Tests.a */; };
+		6E5EF3D31B1005FB001A4BA4 /* CrittercismConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E5EF3D21B1005FB001A4BA4 /* CrittercismConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6E5EF3D51B10063E001A4BA4 /* OptimizelyExperimentData.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E5EF3D41B10063E001A4BA4 /* OptimizelyExperimentData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EB809541AFC135E00959050 /* Amplitude+SSLPinning.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EB809531AFC135E00959050 /* Amplitude+SSLPinning.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EB809561AFC136D00959050 /* AMPURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EB809551AFC136D00959050 /* AMPURLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D31C8F7E18A2D83700DA22A6 /* MPNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = D31C8F7D18A2D83700DA22A6 /* MPNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -511,6 +513,8 @@
 		32F9E6B31907300300ED295B /* libPods-AnalyticsTests.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-AnalyticsTests.a"; path = "Pods/build/Debug-iphoneos/libPods-AnalyticsTests.a"; sourceTree = "<group>"; };
 		32F9E6B61907320700ED295B /* libPods-AnalyticsTests.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-AnalyticsTests.a"; path = "Pods/build/Debug-iphoneos/libPods-AnalyticsTests.a"; sourceTree = "<group>"; };
 		32F9E6B91907323900ED295B /* libPods-Analytics.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-Analytics.a"; path = "Pods/build/Debug-iphoneos/libPods-Analytics.a"; sourceTree = "<group>"; };
+		6E5EF3D21B1005FB001A4BA4 /* CrittercismConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CrittercismConfig.h; path = Pods/CrittercismSDK/CrittercismSDK/CrittercismConfig.h; sourceTree = "<group>"; };
+		6E5EF3D41B10063E001A4BA4 /* OptimizelyExperimentData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OptimizelyExperimentData.h; path = "Pods/Optimizely-iOS-SDK/Optimizely.framework/Headers/OptimizelyExperimentData.h"; sourceTree = "<group>"; };
 		6EB809531AFC135E00959050 /* Amplitude+SSLPinning.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Amplitude+SSLPinning.h"; path = "Pods/Amplitude-iOS/Amplitude/Amplitude+SSLPinning.h"; sourceTree = "<group>"; };
 		6EB809551AFC136D00959050 /* AMPURLConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AMPURLConnection.h; path = "Pods/Amplitude-iOS/Amplitude/AMPURLConnection.h"; sourceTree = "<group>"; };
 		70B38155D048462482A91850 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -736,6 +740,8 @@
 		D3D35174186242B4005586E7 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
+				6E5EF3D41B10063E001A4BA4 /* OptimizelyExperimentData.h */,
+				6E5EF3D21B1005FB001A4BA4 /* CrittercismConfig.h */,
 				6EB809551AFC136D00959050 /* AMPURLConnection.h */,
 				6EB809531AFC135E00959050 /* Amplitude+SSLPinning.h */,
 				32AFA6171A9E98CF00C2AF3E /* Localytics.h */,
@@ -1230,6 +1236,7 @@
 				3252EA581999D5CF0056C32A /* TAGDataLayer.h in Headers */,
 				3252EA591999D5CF0056C32A /* TAGLogger.h in Headers */,
 				3252EA5A1999D5CF0056C32A /* TAGManager.h in Headers */,
+				6E5EF3D31B1005FB001A4BA4 /* CrittercismConfig.h in Headers */,
 				D331BCF2185BFF49007CB22F /* CRFilter.h in Headers */,
 				D331BCF3185BFF4A007CB22F /* CrittercismDelegate.h in Headers */,
 				3252EA431999D5780056C32A /* GAIDictionaryBuilder.h in Headers */,
@@ -1369,6 +1376,7 @@
 				D331BD321860F5F0007CB22F /* TSHelpers.h in Headers */,
 				3252EA7A1999D6390056C32A /* QuantcastDataManager.h in Headers */,
 				3252EA7B1999D6390056C32A /* QuantcastDatabase.h in Headers */,
+				6E5EF3D51B10063E001A4BA4 /* OptimizelyExperimentData.h in Headers */,
 				3252EA7C1999D6390056C32A /* QuantcastEvent.h in Headers */,
 				3252EA7D1999D6390056C32A /* QuantcastEventLogger.h in Headers */,
 				3252EA7E1999D6390056C32A /* QuantcastMeasurement.h in Headers */,

--- a/Analytics/Integrations/Kahuna/SEGKahunaIntegration.m
+++ b/Analytics/Integrations/Kahuna/SEGKahunaIntegration.m
@@ -45,14 +45,6 @@ static NSString* const KAHUNA_NONE = @"None";
 
 + (void)load {
   [SEGAnalytics registerIntegration:self withIdentifier:@"Kahuna"];
-
-  // When this class loads we will register for the 'UIApplicationDidFinishLaunchingNotification' notification.
-  // To receive the notification we will use the SEGKahunaPushMonitor singleton instance.
-  [[NSNotificationCenter defaultCenter] addObserver:[SEGKahunaPushMonitor sharedInstance]
-                                           selector:@selector(didFinishLaunching:)
-                                               name:UIApplicationDidFinishLaunchingNotification
-                                             object:nil];
-
 }
 
 - (id)init {
@@ -89,6 +81,13 @@ static NSString* const KAHUNA_NONE = @"None";
       [SEGKahunaPushMonitor sharedInstance].kahunaInitialized = TRUE;
     }
   }
+
+  // When this class loads we will register for the 'UIApplicationDidFinishLaunchingNotification' notification.
+  // To receive the notification we will use the SEGKahunaPushMonitor singleton instance.
+  [[NSNotificationCenter defaultCenter] addObserver:[SEGKahunaPushMonitor sharedInstance]
+                                           selector:@selector(didFinishLaunching:)
+                                               name:UIApplicationDidFinishLaunchingNotification
+                                             object:nil];
 
   [super start];
 }


### PR DESCRIPTION
Before this change, we were registering the Kahuna observer before enabling it. 