### PR TITLE
Added pushSandbox option to Taplytics.

### DIFF
--- a/Analytics/Integrations/Taplytics/SEGTaplyticsIntegration.m
+++ b/Analytics/Integrations/Taplytics/SEGTaplyticsIntegration.m
@@ -31,6 +31,7 @@
   NSDictionary *options = [[NSMutableDictionary alloc] init];
   [options setValue:[self delayLoad] forKey:@"delayLoad"];
   [options setValue:[self shakeMenu] forKey:@"shakeMenu"];
+  [options setValue:[self pushSandbox] forKey:@"pushSandbox"];
   
   [Taplytics startTaplyticsAPIKey:[self apiKey] options:options];
   
@@ -99,11 +100,15 @@
 }
 
 - (NSNumber *)delayLoad {
-    return (NSNumber *)[self.settings objectForKey:@"delayLoad"];
+  return (NSNumber *)[self.settings objectForKey:@"delayLoad"];
 }
 
 - (NSNumber *)shakeMenu {
-    return (NSNumber *)[self.settings objectForKey:@"shakeMenu"];
+  return (NSNumber *)[self.settings objectForKey:@"shakeMenu"];
+}
+
+- (NSNumber *)pushSandbox {
+  return (NSNumber *)[self.settings objectForKey:@"pushSandbox"];
 }
 
 + (NSString *)identifier {


### PR DESCRIPTION
Hey,

Sorry for the extra PR – I didn't think this option would have been needed, but I was horribly wrong!

It's a quick addition:

- `pushSandbox` – either `@0` or `@1` (a number). If it's `@0`, the push token for the device is assumed to be a production token and if `@1`, it's assumed to be a development token.

Cheers!