### PR TITLE
Update Mixpanel from 2.8.1 to 2.8.2

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -77,7 +77,7 @@
       "name": "Mixpanel",
       "dependencies": [{
         "name": "Mixpanel",
-        "version": "2.8.1"
+        "version": "2.8.2"
       }]
     },
     {


### PR DESCRIPTION
As per the following comment from Mixpanel's team, this changes the mixpanel's version from 2.8.1 to 2.8.2 in order to fix a static library import issue. https://github.com/mixpanel/mixpanel-iphone/issues/299#issuecomment-123511344

It's the only spot where I could find a reference to a specific version of the subpod, let me now if I have to change something else.