### PR TITLE
fix Optimizely import for cocoapods 0.38.1

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		6E8F058C1B42321800305E99 /* SEGOptimizelyIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E8F058B1B42321800305E99 /* SEGOptimizelyIntegrationTests.m */; };
 		6E92C1E71B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E92C1E61B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m */; };
 		6EB2963E1B4C3B2F00805337 /* SEGTapstreamIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB2963D1B4C3B2F00805337 /* SEGTapstreamIntegrationTests.m */; };
+		6EB44C751B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB44C741B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m */; };
 		6EB468211B39CE0B00A0E4B9 /* SEGAmplitudeIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB468201B39CE0B00A0E4B9 /* SEGAmplitudeIntegrationTests.m */; };
 		6EB809541AFC135E00959050 /* Amplitude+SSLPinning.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EB809531AFC135E00959050 /* Amplitude+SSLPinning.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6EB809561AFC136D00959050 /* AMPURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EB809551AFC136D00959050 /* AMPURLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -542,6 +543,7 @@
 		6E8F058B1B42321800305E99 /* SEGOptimizelyIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGOptimizelyIntegrationTests.m; path = Integrations/Optimizely/SEGOptimizelyIntegrationTests.m; sourceTree = "<group>"; };
 		6E92C1E61B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGLocalyticsIntegrationTests.m; path = Integrations/Localytics/SEGLocalyticsIntegrationTests.m; sourceTree = "<group>"; };
 		6EB2963D1B4C3B2F00805337 /* SEGTapstreamIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGTapstreamIntegrationTests.m; path = Integrations/Tapstream/SEGTapstreamIntegrationTests.m; sourceTree = "<group>"; };
+		6EB44C741B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGQuantcastIntegrationTests.m; path = Integrations/Quantcast/SEGQuantcastIntegrationTests.m; sourceTree = "<group>"; };
 		6EB468201B39CE0B00A0E4B9 /* SEGAmplitudeIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGAmplitudeIntegrationTests.m; path = Integrations/Amplitude/SEGAmplitudeIntegrationTests.m; sourceTree = "<group>"; };
 		6EB809531AFC135E00959050 /* Amplitude+SSLPinning.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Amplitude+SSLPinning.h"; path = "Pods/Amplitude-iOS/Amplitude/Amplitude+SSLPinning.h"; sourceTree = "<group>"; };
 		6EB809551AFC136D00959050 /* AMPURLConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AMPURLConnection.h; path = "Pods/Amplitude-iOS/Amplitude/AMPURLConnection.h"; sourceTree = "<group>"; };
@@ -788,6 +790,7 @@
 				6E92C1E51B3DD5030049B5A8 /* Localytics */,
 				6ED462241B42D5E70042BFE4 /* Mixpanel */,
 				6E8F058A1B4231FE00305E99 /* Optimizely */,
+				6EF046EF1B5F117200E973C7 /* Quantcast */,
 				6EFAD9AC1B41A965000664C1 /* Taplytics */,
 				6EB2963C1B4C3A3000805337 /* Tapstream */,
 				79D247F11B4AFDF9002D8F90 /* UXCam */,
@@ -858,6 +861,14 @@
 				6ED462251B42D6020042BFE4 /* SEGMixpanelIntegrationTests.m */,
 			);
 			name = Mixpanel;
+			sourceTree = "<group>";
+		};
+		6EF046EF1B5F117200E973C7 /* Quantcast */ = {
+			isa = PBXGroup;
+			children = (
+				6EB44C741B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m */,
+			);
+			name = Quantcast;
 			sourceTree = "<group>";
 		};
 		6EF6652D1B585DC900DC7EA1 /* AppsFlyer */ = {
@@ -1817,6 +1828,7 @@
 				6E16FFF81B33AD3400B4F7FE /* SEGFlurryIntegrationTests.m in Sources */,
 				3242C9BD1946AFEC00FBE441 /* SEGQuantcastIntegration.m in Sources */,
 				6E12DD831B3CA2A1005E35D0 /* SEGCrittercismIntegrationTests.m in Sources */,
+				6EB44C751B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m in Sources */,
 				6E92C1E71B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m in Sources */,
 				3242C9BC1946AFE300FBE441 /* SEGMixpanelIntegration.m in Sources */,
 				79D247F41B4B00CC002D8F90 /* SEGUXCamIntegration.m in Sources */,

--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		6E85F3941B2F980B00763913 /* MPLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E85F3931B2F980B00763913 /* MPLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E8F058C1B42321800305E99 /* SEGOptimizelyIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E8F058B1B42321800305E99 /* SEGOptimizelyIntegrationTests.m */; };
 		6E92C1E71B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E92C1E61B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m */; };
+		6E9F1EE71B605E7400E55D88 /* SEGApptimizeIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E9F1EE61B605E7400E55D88 /* SEGApptimizeIntegrationTests.m */; };
 		6EB2963E1B4C3B2F00805337 /* SEGTapstreamIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB2963D1B4C3B2F00805337 /* SEGTapstreamIntegrationTests.m */; };
 		6EB44C751B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB44C741B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m */; };
 		6EB468211B39CE0B00A0E4B9 /* SEGAmplitudeIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB468201B39CE0B00A0E4B9 /* SEGAmplitudeIntegrationTests.m */; };
@@ -542,6 +543,7 @@
 		6E85F3931B2F980B00763913 /* MPLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MPLogger.h; path = Pods/Mixpanel/Mixpanel/MPLogger.h; sourceTree = "<group>"; };
 		6E8F058B1B42321800305E99 /* SEGOptimizelyIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGOptimizelyIntegrationTests.m; path = Integrations/Optimizely/SEGOptimizelyIntegrationTests.m; sourceTree = "<group>"; };
 		6E92C1E61B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGLocalyticsIntegrationTests.m; path = Integrations/Localytics/SEGLocalyticsIntegrationTests.m; sourceTree = "<group>"; };
+		6E9F1EE61B605E7400E55D88 /* SEGApptimizeIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGApptimizeIntegrationTests.m; path = Integrations/Apptimize/SEGApptimizeIntegrationTests.m; sourceTree = "<group>"; };
 		6EB2963D1B4C3B2F00805337 /* SEGTapstreamIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGTapstreamIntegrationTests.m; path = Integrations/Tapstream/SEGTapstreamIntegrationTests.m; sourceTree = "<group>"; };
 		6EB44C741B5F11EE0014BCDB /* SEGQuantcastIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGQuantcastIntegrationTests.m; path = Integrations/Quantcast/SEGQuantcastIntegrationTests.m; sourceTree = "<group>"; };
 		6EB468201B39CE0B00A0E4B9 /* SEGAmplitudeIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEGAmplitudeIntegrationTests.m; path = Integrations/Amplitude/SEGAmplitudeIntegrationTests.m; sourceTree = "<group>"; };
@@ -783,6 +785,7 @@
 			children = (
 				6EB4681F1B39CDBD00A0E4B9 /* Amplitude */,
 				6EF6652D1B585DC900DC7EA1 /* AppsFlyer */,
+				6E9F1EE51B605E4100E55D88 /* Apptimize */,
 				6E5146981B3B571D00F8F87C /* Bugsnag */,
 				6EFF0CE31B3B63E6005190A2 /* Countly */,
 				6E12DD811B3CA285005E35D0 /* Crittercism */,
@@ -837,6 +840,14 @@
 				6E92C1E61B3DD5260049B5A8 /* SEGLocalyticsIntegrationTests.m */,
 			);
 			name = Localytics;
+			sourceTree = "<group>";
+		};
+		6E9F1EE51B605E4100E55D88 /* Apptimize */ = {
+			isa = PBXGroup;
+			children = (
+				6E9F1EE61B605E7400E55D88 /* SEGApptimizeIntegrationTests.m */,
+			);
+			name = Apptimize;
 			sourceTree = "<group>";
 		};
 		6EB2963C1B4C3A3000805337 /* Tapstream */ = {
@@ -1807,6 +1818,7 @@
 				6E8F058C1B42321800305E99 /* SEGOptimizelyIntegrationTests.m in Sources */,
 				6EFF0CE51B3B63FB005190A2 /* SEGCountlyIntegrationTests.m in Sources */,
 				3242C9AB1946AB4700FBE441 /* AnalyticsUtilsTests.m in Sources */,
+				6E9F1EE71B605E7400E55D88 /* SEGApptimizeIntegrationTests.m in Sources */,
 				3242C9AC1946AB4700FBE441 /* SegmentioTests.m in Sources */,
 				3242C9BF1946AFF900FBE441 /* SEGTapstreamIntegration.m in Sources */,
 				3242C9B61946AFC800FBE441 /* SEGBugsnagIntegration.m in Sources */,

--- a/Analytics/Integrations/Apptimize/SEGApptimizeIntegration.h
+++ b/Analytics/Integrations/Apptimize/SEGApptimizeIntegration.h
@@ -8,7 +8,11 @@
 
 #import "SEGAnalyticsIntegration.h"
 
+#import <Apptimize/Apptimize.h>
+#import <Apptimize/Apptimize+Segment.h>
 
 @interface SEGApptimizeIntegration : SEGAnalyticsIntegration
+
+@property Class apptimizeClass;
 
 @end

--- a/Analytics/Integrations/Apptimize/SEGApptimizeIntegration.m
+++ b/Analytics/Integrations/Apptimize/SEGApptimizeIntegration.m
@@ -11,10 +11,6 @@
 #import "SEGAnalyticsUtils.h"
 #import "SEGAnalytics.h"
 
-#import <Apptimize/Apptimize.h>
-#import <Apptimize/Apptimize+Segment.h>
-
-
 @implementation SEGApptimizeIntegration
 
 + (NSString *)name { return @"Apptimize"; }
@@ -30,8 +26,9 @@
         self.name = [[self class] name];
         self.valid = NO;
         self.initialized = NO;
+        self.apptimizeClass = [Apptimize class];
 
-        [Apptimize SEG_ensureLibraryHasBeenInitialized];
+        [self.apptimizeClass SEG_ensureLibraryHasBeenInitialized];
     }
     return self;
 }
@@ -43,7 +40,7 @@
 
 - (void)start
 {
-    [Apptimize startApptimizeWithApplicationKey:[self.settings objectForKey:@"appkey"]];
+    [self.apptimizeClass startApptimizeWithApplicationKey:[self.settings objectForKey:@"appkey"]];
 
     if (![(NSNumber *)[self.settings objectForKey:@"listen"] boolValue]) {
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -64,7 +61,7 @@
     // Apptimize doesn't notify with IDs, so we iterate over all experiments to find the matching one.
     NSString *name = notification.userInfo[ApptimizeTestNameUserInfoKey];
     NSString *variant = notification.userInfo[ApptimizeVariantNameUserInfoKey];
-    [[Apptimize testInfo] enumerateKeysAndObjectsUsingBlock:^(id key, id<ApptimizeTestInfo> experiment, BOOL *stop) {
+    [[self.apptimizeClass testInfo] enumerateKeysAndObjectsUsingBlock:^(id key, id<ApptimizeTestInfo> experiment, BOOL *stop) {
       BOOL match = [experiment.testName isEqualToString:name] && [experiment.enrolledVariantName isEqualToString:variant];
       if (!match) {
           return;
@@ -83,22 +80,22 @@
 - (void)identify:(NSString *)userId traits:(NSDictionary *)traits options:(NSDictionary *)options
 {
     if (userId != nil) {
-        [Apptimize setUserAttributeString:userId forKey:@"user_id"];
+        [self.apptimizeClass setUserAttributeString:userId forKey:@"user_id"];
     }
 
     if (traits) {
-        [Apptimize SEG_setUserAttributesFromDictionary:traits];
+        [self.apptimizeClass SEG_setUserAttributesFromDictionary:traits];
     }
 }
 
 - (void)track:(NSString *)event properties:(NSDictionary *)properties options:(NSDictionary *)options
 {
-    [Apptimize SEG_track:event attributes:properties];
+    [self.apptimizeClass SEG_track:event attributes:properties];
 }
 
 - (void)reset
 {
-    [Apptimize SEG_resetUserData];
+    [self.apptimizeClass SEG_resetUserData];
 }
 
 @end

--- a/Analytics/Integrations/Optimizely/SEGOptimizelyIntegration.m
+++ b/Analytics/Integrations/Optimizely/SEGOptimizelyIntegration.m
@@ -9,7 +9,7 @@
 #import "SEGOptimizelyIntegration.h"
 #import "SEGAnalytics.h"
 #import "SEGAnalyticsUtils.h"
-#import <Optimizely-iOS-SDK/Optimizely.h>
+#import <Optimizely/Optimizely.h>
 
 NSString *SEGMixpanelClass = @"Mixpanel";
 

--- a/Analytics/Integrations/Quantcast/SEGQuantcastIntegration.h
+++ b/Analytics/Integrations/Quantcast/SEGQuantcastIntegration.h
@@ -7,8 +7,11 @@
 //
 
 #import "SEGAnalyticsIntegration.h"
+#import <Quantcast-Measure/QuantcastMeasurement.h>
 
 
 @interface SEGQuantcastIntegration : SEGAnalyticsIntegration
+
+@property (assign) QuantcastMeasurement *quantcast;
 
 @end

--- a/Analytics/Integrations/Quantcast/SEGQuantcastIntegration.m
+++ b/Analytics/Integrations/Quantcast/SEGQuantcastIntegration.m
@@ -9,7 +9,6 @@
 #import "SEGQuantcastIntegration.h"
 #import "SEGAnalytics.h"
 #import "SEGAnalyticsUtils.h"
-#import <Quantcast-Measure/QuantcastMeasurement.h>
 
 
 @implementation SEGQuantcastIntegration
@@ -23,6 +22,7 @@
 {
     if (self = [super init]) {
         self.name = self.class.name;
+        self.quantcast = [QuantcastMeasurement sharedInstance];
     }
     return self;
 }
@@ -34,23 +34,23 @@
 
 - (void)start
 {
-    [[QuantcastMeasurement sharedInstance] setupMeasurementSessionWithAPIKey:self.settings[@"apiKey"] userIdentifier:self.settings[@"userIdentifier"] labels:self.settings[@"labels"]];
+    [self.quantcast setupMeasurementSessionWithAPIKey:self.settings[@"apiKey"] userIdentifier:self.settings[@"userIdentifier"] labels:self.settings[@"labels"]];
     [super start];
 }
 
 - (void)track:(NSString *)event properties:(NSDictionary *)properties options:(NSDictionary *)options
 {
-    [[QuantcastMeasurement sharedInstance] logEvent:event withLabels:self.settings[@"labels"]];
+    [self.quantcast logEvent:event withLabels:self.settings[@"labels"]];
 }
 
 - (void)screen:(NSString *)screenTitle properties:(NSDictionary *)properties options:(NSDictionary *)options
 {
-    [[QuantcastMeasurement sharedInstance] logEvent:SEGEventNameForScreenTitle(screenTitle) withLabels:self.settings[@"labels"]];
+    [self.quantcast logEvent:SEGEventNameForScreenTitle(screenTitle) withLabels:self.settings[@"labels"]];
 }
 
 - (void)identify:(NSString *)userId traits:(NSDictionary *)traits options:(NSDictionary *)options
 {
-    [[QuantcastMeasurement sharedInstance] recordUserIdentifier:userId withLabels:self.settings[@"labels"]];
+    [self.quantcast recordUserIdentifier:userId withLabels:self.settings[@"labels"]];
 }
 
 #pragma mark - Private

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,11 +15,9 @@ PODS:
   - GoogleIDFASupport (3.12.0)
   - KahunaSDK (1.0.570)
   - Localytics (3.3.0)
-  - Mixpanel (2.8.1):
-    - Mixpanel/Mixpanel (= 2.8.1)
-  - Mixpanel/Mixpanel (2.8.1):
-    - Mixpanel/MPCategoryHelpers
-  - Mixpanel/MPCategoryHelpers (2.8.1)
+  - Mixpanel (2.8.2):
+    - Mixpanel/Mixpanel (= 2.8.2)
+  - Mixpanel/Mixpanel (2.8.2)
   - MoEngage-iOS-SDK (1.4.3)
   - OCHamcrest (4.1.1)
   - OCMock (3.1.2)
@@ -47,7 +45,7 @@ DEPENDENCIES:
   - GoogleIDFASupport (= 3.12.0)
   - KahunaSDK (= 1.0.570)
   - Localytics (= 3.3.0)
-  - Mixpanel (= 2.8.1)
+  - Mixpanel (= 2.8.2)
   - MoEngage-iOS-SDK (= 1.4.3)
   - OCMock (~> 3.1.2)
   - OCMockito (~> 1.4.0)
@@ -71,7 +69,7 @@ SPEC CHECKSUMS:
   GoogleIDFASupport: 0dd25ffdd152fd8e3deefd72978b42ef818ef0fa
   KahunaSDK: ea15fdf9757c4d9bf639bf190888e20b688a30ed
   Localytics: 64ada284cde3f2b30fb04272d5d735d49657d0ab
-  Mixpanel: 93c4825025e6380ced273ed7178496282e385077
+  Mixpanel: f4d71ac2a306e7cda6ad03d4a2be249a0fd7a967
   MoEngage-iOS-SDK: 81be7a433349a7d535c905a08629359eeefe0952
   OCHamcrest: 6f03ffa81d12feab872638490a44ab0a6d3aca10
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Amplitude-iOS (2.5.1)
-  - AppsFlyer-SDK (2.5.3.15.1)
+  - AppsFlyer-SDK (2.5.3.19)
   - Apptimize (2.11.0.1)
   - Bugsnag (4.0.7):
     - Bugsnag/no-arc (= 4.0.7)
@@ -34,7 +34,7 @@ PODS:
 
 DEPENDENCIES:
   - Amplitude-iOS (= 2.5.1)
-  - AppsFlyer-SDK (= 2.5.3.15.1)
+  - AppsFlyer-SDK (= 2.5.3.19)
   - Apptimize (= 2.11.0.1)
   - Bugsnag (= 4.0.7)
   - Countly (= 15.06.01)
@@ -58,7 +58,7 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   Amplitude-iOS: 1108012e40096d339d768cb8a6d79c774f47da2c
-  AppsFlyer-SDK: 34670f7a518e82cfba54dc8ad7738bacf4117b9c
+  AppsFlyer-SDK: a0e68e41c6ece355c4b34cf3cdceae08f7da89b0
   Apptimize: 5ec482ca36dbec7bd5017f546509136229aa1822
   Bugsnag: 5861d8519d30063abe7b3fcdcf4114a6dddab27a
   Countly: 2151c5286995b84972ba4a92c3fba6b5fafce6bb

--- a/iOS Tests/Integrations/Apptimize/SEGApptimizeIntegrationTests.m
+++ b/iOS Tests/Integrations/Apptimize/SEGApptimizeIntegrationTests.m
@@ -1,0 +1,61 @@
+//
+//  SEGApptimizeIntegrationTests.m
+//  Analytics
+//
+//  Created by Prateek Srivastava on 2015-07-22.
+//  Copyright (c) 2015 Segment.io. All rights reserved.
+//
+
+#import "SEGApptimizeIntegration.h"
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+#define MOCKITO_SHORTHAND
+#import <OCMockito/OCMockito.h>
+#import <XCTest/XCTest.h>
+
+@interface SEGApptimizeIntegrationTests : XCTestCase
+
+@property SEGApptimizeIntegration *integration;
+@property Class apptimizeClassMock;
+
+@end
+
+
+@implementation SEGApptimizeIntegrationTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    _apptimizeClassMock = mockClass([Apptimize class]);
+
+    _integration = [[SEGApptimizeIntegration alloc] init];
+    [_integration setApptimizeClass:_apptimizeClassMock];
+    [_integration updateSettings:@{ @"apiKey" : @"foo" }];
+}
+
+- (void)testIdentify
+{
+    [_integration identify:@"foo" traits:@{ @"bar" : @"qaz" } options:nil];
+
+    [verifyCount(_apptimizeClassMock, times(1)) setUserAttributeString:@"foo" forKey:@"user_id"];
+    [verifyCount(_apptimizeClassMock, times(1)) SEG_setUserAttributesFromDictionary:@{ @"bar" : @"qaz" }];
+}
+
+- (void)testTrack
+{
+    [_integration track:@"foo" properties:@{ @"bar" : @"qaz" } options:nil];
+
+    [verifyCount(_apptimizeClassMock, times(1)) SEG_track:@"foo" attributes:@{ @"bar" : @"qaz" }];
+}
+
+- (void)testReset
+{
+    [_integration reset];
+
+    [verifyCount(_apptimizeClassMock, times(1)) SEG_resetUserData];
+}
+
+@end

--- a/iOS Tests/Integrations/Quantcast/SEGQuantcastIntegrationTests.m
+++ b/iOS Tests/Integrations/Quantcast/SEGQuantcastIntegrationTests.m
@@ -1,0 +1,62 @@
+//
+//  SEGQuantastIntegrationTests.m
+//  Analytics
+//
+//  Created by Prateek Srivastava on 2015-07-21.
+//  Copyright (c) 2015 Segment.io. All rights reserved.
+//
+
+#import "SEGQuantcastIntegration.h"
+#import <XCTest/XCTest.h>
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+#define MOCKITO_SHORTHAND
+#import <OCMockito/OCMockito.h>
+
+@interface SEGQuantastIntegrationTests : XCTestCase
+
+@property SEGQuantcastIntegration *integration;
+@property QuantcastMeasurement *quantcastMock;
+
+@end
+
+
+@implementation SEGQuantastIntegrationTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.quantcastMock = mock([QuantcastMeasurement class]);
+    self.integration = [[SEGQuantcastIntegration alloc] init];
+
+    [self.integration setQuantcast:self.quantcastMock];
+    [self.integration updateSettings:@{ @"apiKey" : @"foo",
+                                        @"userIdentifier" : @"bar",
+                                        @"labels" : @[] }];
+}
+
+- (void)testTrack
+{
+    [self.integration track:@"foo" properties:nil options:nil];
+
+    [verifyCount(self.quantcastMock, times(1)) logEvent:@"foo" withLabels:@[]];
+}
+
+- (void)testScreen
+{
+    [self.integration screen:@"foo" properties:nil options:nil];
+
+    [verifyCount(self.quantcastMock, times(1)) logEvent:@"Viewed foo Screen" withLabels:@[]];
+}
+
+- (void)testIdentify
+{
+    [self.integration identify:@"foo" traits:nil options:nil];
+
+    [verifyCount(self.quantcastMock, times(1)) recordUserIdentifier:@"foo" withLabels:@[]];
+}
+
+@end

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -11,7 +11,7 @@
       "name": "AppsFlyer",
       "dependencies": [{
         "name": "AppsFlyer-SDK",
-        "version": "2.5.3.15.1"
+        "version": "2.5.3.19"
       }]
     },
     {

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -77,7 +77,7 @@
       "name": "Mixpanel",
       "dependencies": [{
         "name": "Mixpanel",
-        "version": "2.8.1"
+        "version": "2.8.2"
       }]
     },
     {


### PR DESCRIPTION
Due to a change in cocoapods the Optimizely framework is now built differently therefore Optimizely framework integration fails on build.

It won't pass any CI tests unless cocoapods 0.38.1 is being used.