### PR TITLE
Update Taplytics to 2.3.22

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -109,7 +109,7 @@
       "name": "Taplytics",
       "dependencies": [{
         "name": "Taplytics",
-        "version": "2.3.12"
+        "version": "2.3.22"
       }]
     },
     {


### PR DESCRIPTION
@f2prateek I was unable to run `make build` got an error with `MoEngage-iOS-SDK`. I have 0.38.2 of cocoapods installed.

```
Updating local specs repositories
Analyzing dependencies
[!] Unable to satisfy the following requirements:

- `MoEngage-iOS-SDK (= 1.4.3)` required by `Podfile`
- `MoEngage-iOS-SDK (= 1.4.3)` required by `Podfile`
- `MoEngage-iOS-SDK (= 1.4.3)` required by `Podfile.lock`
make: *** [deps] Error 1
```