### PR TITLE
Update Taplytics to 2.4.0

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -109,7 +109,7 @@
       "name": "Taplytics",
       "dependencies": [{
         "name": "Taplytics",
-        "version": "2.3.12"
+        "version": "2.4.0"
       }]
     },
     {


### PR DESCRIPTION
@f2prateek was still unable to run `make build` getting this when I remove the `Podfile.lock` file: 
```
Updating local specs repositories
Analyzing dependencies
[!] Unable to satisfy the following requirements:

- `MoEngage-iOS-SDK (= 1.4.3)` required by `Podfile`
- `MoEngage-iOS-SDK (= 1.4.3)` required by `Podfile`
make: *** [deps] Error 1
```