### PR TITLE
Updating Taplytics to 2.4.8

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -109,7 +109,7 @@
       "name": "Taplytics",
       "dependencies": [{
         "name": "Taplytics",
-        "version": "2.4.0"
+        "version": "2.4.8"
       }]
     },
     {


### PR DESCRIPTION
Ran `make build`, ran into a new issue: 
```
Generating Pods project
[!] An error occurred while processing the post-install hook of the Podfile.

undefined method `project' for #<Pod::Installer:0x007fb56c8d7b78>

/Users/jonathannorris/git/analytics-ios/Podfile:30:in `block (2 levels) in from_ruby'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-core-0.38.2/lib/cocoapods-core/podfile.rb:170:in `call'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-core-0.38.2/lib/cocoapods-core/podfile.rb:170:in `post_install!'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/installer.rb:764:in `run_podfile_post_install_hook'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/installer.rb:752:in `block in run_podfile_post_install_hooks'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/user_interface.rb:140:in `message'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/installer.rb:751:in `run_podfile_post_install_hooks'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/installer.rb:155:in `block in generate_pods_project'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/user_interface.rb:59:in `section'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/installer.rb:150:in `generate_pods_project'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/installer.rb:110:in `install!'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/command/project.rb:71:in `run_install_with_update'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/command/project.rb:101:in `run'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/claide-0.9.1/lib/claide/command.rb:312:in `run'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/lib/cocoapods/command.rb:48:in `run'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/gems/cocoapods-0.38.2/bin/pod:44:in `<top (required)>'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/bin/pod:23:in `load'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/bin/pod:23:in `<main>'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `eval'
/Users/jonathannorris/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `<main>'
make: *** [deps] Error 1
```