### PR TITLE
Updating Amplitude SDK v3.0.0

### DIFF
--- a/Analytics/Integrations/Amplitude/SEGAmplitudeIntegration.m
+++ b/Analytics/Integrations/Amplitude/SEGAmplitudeIntegration.m
@@ -29,6 +29,9 @@
 - (void)start
 {
     NSString *apiKey = [self.settings objectForKey:@"apiKey"];
+    if ([(NSNumber *)[self.settings objectForKey:@"trackSessionEvents"] boolValue]) {
+        [Amplitude instance].trackingSessionEvents = true;
+    }
     [[Amplitude instance] initializeApiKey:apiKey];
     SEGLog(@"AmplitudeIntegration initialized.");
     [super start];

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Amplitude-iOS (2.5.1)
+  - Amplitude-iOS (3.0.0)
   - AppsFlyer-SDK (2.5.3.15.1)
   - Apptimize (2.11.0.1)
   - Bugsnag (4.0.7):
@@ -33,7 +33,7 @@ PODS:
   - UXCam (2.0.5)
 
 DEPENDENCIES:
-  - Amplitude-iOS (= 2.5.1)
+  - Amplitude-iOS (= 3.0.0)
   - AppsFlyer-SDK (= 2.5.3.15.1)
   - Apptimize (= 2.11.0.1)
   - Bugsnag (= 4.0.7)
@@ -57,7 +57,7 @@ DEPENDENCIES:
   - UXCam (= 2.0.5)
 
 SPEC CHECKSUMS:
-  Amplitude-iOS: 1108012e40096d339d768cb8a6d79c774f47da2c
+  Amplitude-iOS: 07875b822c2c935ea7f8021830d375ed4d812d31
   AppsFlyer-SDK: 34670f7a518e82cfba54dc8ad7738bacf4117b9c
   Apptimize: 5ec482ca36dbec7bd5017f546509136229aa1822
   Bugsnag: 5861d8519d30063abe7b3fcdcf4114a6dddab27a

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -4,7 +4,7 @@
       "name": "Amplitude",
       "dependencies": [{
         "name": "Amplitude-iOS",
-        "version": "2.5.1"
+        "version": "3.0.0"
       }]
     },
     {


### PR DESCRIPTION
Updating Amplitude SDK to v3.0.0

* No longer log start/end sessions by default; however, users can re-enable them by setting trackSessionEvents to true. This is exposed in Segment via trackSessionEvents settings option.

(Also updated Cocoapods to 0.38?)