### PR TITLE
update localytics from 3.3.0 to  3.5.0

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -70,7 +70,7 @@
       "name": "Localytics",
       "dependencies": [{
         "name": "Localytics",
-        "version": "3.3.0"
+        "version": "3.5.0"
       }]
     },
     {


### PR DESCRIPTION
From localytics changelog : 

3.5.0: August 28, 2015
Fix to in-app messaging for iOS 9 compatibility
Improved support for full-screen in-app messages for apps that support multiple orientations
3.4.0: July 1, 2015
Support for scheduling automation for in-app messaging
Support for control groups for in-app messaging
Added ability to suppress attachment of adid to in-app URLs upon click-through
tagScreen now reports consecutive tags of the same screen as one tag