### PR TITLE
Use invariant locale for ISO8601 date formatter

### DIFF
--- a/Analytics/SEGAnalyticsUtils.m
+++ b/Analytics/SEGAnalyticsUtils.m
@@ -31,6 +31,7 @@ NSString *iso8601FormattedString(NSDate *date)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
       dateFormatter = [[NSDateFormatter alloc] init];
+      dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
       dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ssZ";
     });
     return [dateFormatter stringFromDate:date];


### PR DESCRIPTION
Per https://developer.apple.com/library/ios/qa/qa1480/_index.html I think Segment should be using the `en_US_POSIX` locale when formatting dates for tracking. Otherwise the device locale generates an inconsistent string which cannot reliably be parsed by integrations.