### PR TITLE
Update Flurry integration

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -275,7 +275,6 @@
 		D331BD371860F5F0007CB22F /* TSResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = D331BD291860F5F0007CB22F /* TSResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D331BD381860F5F0007CB22F /* TSUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = D331BD2A1860F5F0007CB22F /* TSUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D371F32E185942BB0053337D /* Crittercism.h in Headers */ = {isa = PBXBuildFile; fileRef = D371F32D185942BB0053337D /* Crittercism.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D371F330185942C90053337D /* Flurry.h in Headers */ = {isa = PBXBuildFile; fileRef = D371F32F185942C90053337D /* Flurry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D371F334185943170053337D /* Mixpanel.h in Headers */ = {isa = PBXBuildFile; fileRef = D371F333185943170053337D /* Mixpanel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D3EDB65618C315F100A88A7E /* SEGAmplitudeIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = D3EDB63918C315F100A88A7E /* SEGAmplitudeIntegration.h */; };
 		D3EDB65718C315F100A88A7E /* SEGAmplitudeIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = D3EDB63A18C315F100A88A7E /* SEGAmplitudeIntegration.m */; };
@@ -590,7 +589,6 @@
 		D369201C181604CD009F24C0 /* libFlurry_4.2.4.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFlurry_4.2.4.a; path = Pods/FlurrySDK/Flurry/libFlurry_4.2.4.a; sourceTree = "<group>"; };
 		D36ABA63182F09F3001EB84B /* admsAppLibrary.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = admsAppLibrary.a; path = Pods/Omniture/admsAppLibrary.a; sourceTree = "<group>"; };
 		D371F32D185942BB0053337D /* Crittercism.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Crittercism.h; path = Pods/CrittercismSDK/CrittercismSDK/Crittercism.h; sourceTree = "<group>"; };
-		D371F32F185942C90053337D /* Flurry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Flurry.h; path = Pods/FlurrySDK/Flurry/Flurry.h; sourceTree = "<group>"; };
 		D371F333185943170053337D /* Mixpanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Mixpanel.h; path = Pods/Mixpanel/Mixpanel/Mixpanel.h; sourceTree = "<group>"; };
 		D37F756C189237360037E851 /* libCrittercism_v4_3_1.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libCrittercism_v4_3_1.a; path = Pods/CrittercismSDK/CrittercismSDK/libCrittercism_v4_3_1.a; sourceTree = "<group>"; };
 		D37F756E189237430037E851 /* libFlurry_4.3.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFlurry_4.3.0.a; path = Pods/FlurrySDK/Flurry/libFlurry_4.3.0.a; sourceTree = "<group>"; };
@@ -1063,7 +1061,6 @@
 				D331BCF0185BFF49007CB22F /* CRFilter.h */,
 				D371F32D185942BB0053337D /* Crittercism.h */,
 				D331BCF1185BFF49007CB22F /* CrittercismDelegate.h */,
-				D371F32F185942C90053337D /* Flurry.h */,
 				3252EA951999D7040056C32A /* Mixpanel.h */,
 				3252EA8F1999D7040056C32A /* MPNotification.h */,
 				3252EA6A1999D5FD0056C32A /* MPNotificationViewController.h */,
@@ -1431,7 +1428,6 @@
 				6E2AFA421B55852400C8A14E /* MOInbox.h in Headers */,
 				6E2AFA431B55852400C8A14E /* MOInboxViewController.h in Headers */,
 				D3EDB65818C315F100A88A7E /* SEGBugsnagIntegration.h in Headers */,
-				D371F330185942C90053337D /* Flurry.h in Headers */,
 				6E2AFA3E1B55850C00C8A14E /* MOEHelperConstants.h in Headers */,
 				6E2AFA3F1B55850C00C8A14E /* MoEngage.h in Headers */,
 				D3EDB65E18C315F100A88A7E /* SEGFlurryIntegration.h in Headers */,

--- a/Analytics/Integrations/Flurry/SEGFlurryIntegration.m
+++ b/Analytics/Integrations/Flurry/SEGFlurryIntegration.m
@@ -1,7 +1,7 @@
 #import "SEGFlurryIntegration.h"
 #import "SEGAnalyticsUtils.h"
 #import "SEGAnalytics.h"
-#import <Flurry.h>
+#import <Flurry-iOS-SDK/Flurry.h>
 #import <objc/message.h>
 
 
@@ -88,19 +88,6 @@
     // http://stackoverflow.com/questions/5404513/tracking-page-views-with-the-help-of-flurry-sdk
 
     [Flurry logPageView];
-}
-
-- (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options
-{
-    // Why oh why does Flurry require an NSString?! NSData was good enough for everyone else lol
-    // http://stackoverflow.com/a/9372848/1426850
-    const unsigned *tokenBytes = [deviceToken bytes];
-    NSString *hexToken = [NSString stringWithFormat:@"%08x%08x%08x%08x%08x%08x%08x%08x",
-                                                    ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
-                                                    ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
-                                                    ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
-    // cocoapods validation cant find +[Flurry setPushToken:]
-    ((void (*)(Class, SEL, NSString *))objc_msgSend)(Flurry.class, NSSelectorFromString(@"setPushToken:"), hexToken);
 }
 
 @end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,9 +9,7 @@ PODS:
   - Countly (15.06.01)
   - CrittercismSDK (5.2.0)
   - Expecta (1.0.0)
-  - FlurrySDK (6.5.0):
-    - FlurrySDK/FlurrySDK (= 6.5.0)
-  - FlurrySDK/FlurrySDK (6.5.0)
+  - Flurry-iOS-SDK/FlurrySDK (7.1.0)
   - FMDB/common (2.5)
   - FMDB/standard (2.5):
     - FMDB/common
@@ -44,7 +42,7 @@ DEPENDENCIES:
   - Countly (= 15.06.01)
   - CrittercismSDK (= 5.2.0)
   - Expecta (~> 1.0.0)
-  - FlurrySDK (= 6.5.0)
+  - Flurry-iOS-SDK/FlurrySDK (= 7.1.0)
   - GoogleAnalytics (= 3.13.0)
   - GoogleIDFASupport (= 3.12.0)
   - Kahuna (= 2.0.3)
@@ -68,7 +66,7 @@ SPEC CHECKSUMS:
   Countly: 2151c5286995b84972ba4a92c3fba6b5fafce6bb
   CrittercismSDK: b22f9541803c2babb1c8996862b097dc47ec7105
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
-  FlurrySDK: 820acaa95f7ec08797517720714783928d3e386b
+  Flurry-iOS-SDK: 7b3fe6c3344c82b73c4c84163652eada84fbfcf4
   FMDB: 96e8f1bcc1329e269330f99770ad4285d9003e52
   GoogleAnalytics: fcf1f1cad57ae1a9a53520018f0f680ceeeb8b49
   GoogleIDFASupport: 0dd25ffdd152fd8e3deefd72978b42ef818ef0fa

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -45,8 +45,8 @@
     {
       "name": "Flurry",
       "dependencies": [{
-        "name": "FlurrySDK",
-        "version": "6.5.0"
+        "name": "Flurry-iOS-SDK/FlurrySDK",
+        "version": "7.1.0"
       }]
     },
     {


### PR DESCRIPTION
* Update the SDK to version 7.1.0 (newer versions don't work due to
  Xcode 7) incompatibility.
* Remove registerForRemoteNotificationsWithDeviceToken call, since
 `setPushToken` doesn't exist anymore.