### PR TITLE
[Identify] Make Anonymous ID customisable.

### DIFF
--- a/Pod/Classes/Integrations/SEGIdentifyPayload.h
+++ b/Pod/Classes/Integrations/SEGIdentifyPayload.h
@@ -6,9 +6,12 @@
 
 @property (nonatomic, readonly) NSString *userId;
 
+@property (nonatomic, readonly) NSString *anonymousId;
+
 @property (nonatomic, readonly) NSDictionary *traits;
 
 - (instancetype)initWithUserId:(NSString *)userId
+                   anonymousId:(NSString *)anonymousId
                         traits:(NSDictionary *)traits
                        context:(NSDictionary *)context
                   integrations:(NSDictionary *)integrations;

--- a/Pod/Classes/Integrations/SEGIdentifyPayload.m
+++ b/Pod/Classes/Integrations/SEGIdentifyPayload.m
@@ -4,12 +4,14 @@
 @implementation SEGIdentifyPayload
 
 - (instancetype)initWithUserId:(NSString *)userId
+                   anonymousId:(NSString *)anonymousId
                         traits:(NSDictionary *)traits
                        context:(NSDictionary *)context
                   integrations:(NSDictionary *)integrations
 {
     if (self = [super initWithContext:context integrations:integrations]) {
         _userId = [userId copy];
+        _anonymousId = [anonymousId copy];
         _traits = [traits copy];
     }
     return self;

--- a/Pod/Classes/SEGAnalytics.h
+++ b/Pod/Classes/SEGAnalytics.h
@@ -88,6 +88,8 @@
 
  @param traits        A dictionary of traits you know about the user. Things like: email, name, plan, etc.
 
+ @param options       A dictionary of options, such as the `@"anonymousId"` key. If no anonymous ID is specified one will be generated for you.
+
  @discussion
  When you learn more about who your user is, you can record that information with identify.
 

--- a/Pod/Classes/SEGAnalytics.m
+++ b/Pod/Classes/SEGAnalytics.m
@@ -186,6 +186,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     NSCParameterAssert(userId.length > 0 || traits.count > 0);
 
     SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:userId
+                                                                 anonymousId:[options objectForKey:@"anonymousId"]
                                                                       traits:SEGCoerceDictionary(traits)
                                                                      context:SEGCoerceDictionary([options objectForKey:@"context"])
                                                                 integrations:[options objectForKey:@"integrations"]];


### PR DESCRIPTION
This is a first stab at making the Anonymous ID customisable, as asked about in #482. Some more background can be found in [this PR](https://github.com/artsy/eigen/pull/958) on our app.

This is very much a work in progress, I did the bare minimum to get _what we needed_ to work, so now I’m looking for feedback on:

* Is adding this feature conceptually ok?
* Would you prefer I refactor the `-getAnonymousId:` code into e.g. the getter of the `anonymousId` property, or what is the style you’d prefer?
* General code-style