### PR TITLE
Store `userId` and `anonymousId` in NSUserDefaults

### DIFF
--- a/Pod/Classes/Internal/SEGSegmentIntegration.m
+++ b/Pod/Classes/Internal/SEGSegmentIntegration.m
@@ -24,6 +24,8 @@ NSString *const SEGADClientClass = @"ADClient";
 
 NSString *const SEGUserIdKey = @"SEGUserId";
 NSString *const SEGAnonymousIdKey = @"SEGAnonymousId";
+NSString *const SEGQueueKey = @"SEGQueue";
+NSString *const SEGTraitsKey = @"SEGTraits";
 
 static NSString *GenerateUUIDString()
 {
@@ -267,6 +269,7 @@ static BOOL GetAdTrackingEnabled()
 {
     [self dispatchBackground:^{
         [self.traits addEntriesFromDictionary:traits];
+        [[NSUserDefaults standardUserDefaults] setObject:[self.traits copy] forKey:SEGTraitsKey];
         [[self.traits copy] writeToURL:self.traitsURL atomically:YES];
     }];
 }
@@ -388,7 +391,7 @@ static BOOL GetAdTrackingEnabled()
 {
     @try {
         [self.queue addObject:payload];
-        [[self.queue copy] writeToURL:[self queueURL] atomically:YES];
+        [self persistQueue];
         [self flushQueueByLength];
 
     }
@@ -460,6 +463,8 @@ static BOOL GetAdTrackingEnabled()
     [self dispatchBackgroundAndWait:^{
         [[NSUserDefaults standardUserDefaults] setValue:nil forKey:SEGUserIdKey];
         [[NSUserDefaults standardUserDefaults] setValue:nil forKey:SEGAnonymousIdKey];
+        [[NSUserDefaults standardUserDefaults] setValue:@[] forKey:SEGQueueKey];
+        [[NSUserDefaults standardUserDefaults] setValue:nil forKey:SEGTraitsKey];
         [[NSFileManager defaultManager] removeItemAtURL:self.userIDURL error:NULL];
         [[NSFileManager defaultManager] removeItemAtURL:self.traitsURL error:NULL];
         [[NSFileManager defaultManager] removeItemAtURL:self.queueURL error:NULL];
@@ -498,7 +503,7 @@ static BOOL GetAdTrackingEnabled()
                                                          } else {
                                                              SEGLog(@"%@ API request success 200", self);
                                                              [self.queue removeObjectsInArray:self.batch];
-                                                             [[self.queue copy] writeToURL:[self queueURL] atomically:YES];
+                                                             [self persistQueue];
                                                              [self notifyForName:SEGSegmentRequestDidSucceedNotification userInfo:self.batch];
                                                          }
 
@@ -522,7 +527,8 @@ static BOOL GetAdTrackingEnabled()
 {
     [self dispatchBackgroundAndWait:^{
         if (self.queue.count)
-            [[self.queue copy] writeToURL:self.queueURL atomically:YES];
+            
+            [self persistQueue];
     }];
 }
 
@@ -531,7 +537,7 @@ static BOOL GetAdTrackingEnabled()
 - (NSMutableArray *)queue
 {
     if (!_queue) {
-        _queue = [NSMutableArray arrayWithContentsOfURL:self.queueURL] ?: [[NSMutableArray alloc] init];
+        _queue = ([[NSUserDefaults standardUserDefaults] objectForKey:SEGQueueKey] ?: [NSMutableArray arrayWithContentsOfURL:self.queueURL]) ?: [[NSMutableArray alloc] init];
     }
     return _queue;
 }
@@ -539,7 +545,7 @@ static BOOL GetAdTrackingEnabled()
 - (NSMutableDictionary *)traits
 {
     if (!_traits) {
-        _traits = [NSMutableDictionary dictionaryWithContentsOfURL:self.traitsURL] ?: [[NSMutableDictionary alloc] init];
+        _traits = ([[NSUserDefaults standardUserDefaults] objectForKey:SEGTraitsKey] ?: [NSMutableDictionary dictionaryWithContentsOfURL:self.traitsURL]) ?: [[NSMutableDictionary alloc] init];
     }
     return _traits;
 }
@@ -568,6 +574,13 @@ static BOOL GetAdTrackingEnabled()
 {
     return SEGAnalyticsURLForFilename(@"segmentio.traits.plist");
 }
+
+- (void)persistQueue
+{
+    [[NSUserDefaults standardUserDefaults] setValue:[self.queue copy] forKey:SEGQueueKey];
+    [[self.queue copy] writeToURL:self.queueURL atomically:YES];
+}
+
 
 - (NSString *)getAnonymousId:(BOOL)reset
 {

--- a/Pod/Classes/Internal/SEGSegmentIntegration.m
+++ b/Pod/Classes/Internal/SEGSegmentIntegration.m
@@ -579,6 +579,7 @@ static BOOL GetAdTrackingEnabled()
     if (!anonymousId || reset) {
         anonymousId = GenerateUUIDString();
         SEGLog(@"New anonymousId: %@", anonymousId);
+        [[NSUserDefaults standardUserDefaults] setObject:anonymousId forKey:SEGAnonymousIdKey];
         [anonymousId writeToURL:url atomically:YES encoding:NSUTF8StringEncoding error:NULL];
     }
     return anonymousId;


### PR DESCRIPTION
When looking for the `userId` and `anonymousId`, look first in
`NSUserDefaults`, then in the stored file. The stored file is persistent
in most cases, but on tvOS, the file system should be treated as
temporary. That means we lose the identity of the user is lost as soon
as the file system is cleared on the Apple TV.

This solution does not replace these file, but simply augments them,
using `NSUserDefaults` as a cache in front of the files. The only
rationale I can think of for using files is that sometimes apps blow
away their defaults.

There is probably another approach here which finds a happy medium, but
`NSUserDefaults` is all we've really got (unless you want to play with
the keychain, and I sure don't) on tvOS.