### PR TITLE
Fix Crash: Mutable queue and traits

### DIFF
--- a/Pod/Classes/Internal/SEGSegmentIntegration.m
+++ b/Pod/Classes/Internal/SEGSegmentIntegration.m
@@ -539,7 +539,7 @@ static BOOL GetAdTrackingEnabled()
 - (NSMutableArray *)queue
 {
     if (!_queue) {
-        _queue = ([[NSUserDefaults standardUserDefaults] objectForKey:SEGQueueKey] ?: [NSMutableArray arrayWithContentsOfURL:self.queueURL]) ?: [[NSMutableArray alloc] init];
+        _queue = ([[[NSUserDefaults standardUserDefaults] objectForKey:SEGQueueKey] mutableCopy] ?: [NSMutableArray arrayWithContentsOfURL:self.queueURL]) ?: [[NSMutableArray alloc] init];
     }
     return _queue;
 }
@@ -547,7 +547,7 @@ static BOOL GetAdTrackingEnabled()
 - (NSMutableDictionary *)traits
 {
     if (!_traits) {
-        _traits = ([[NSUserDefaults standardUserDefaults] objectForKey:SEGTraitsKey] ?: [NSMutableDictionary dictionaryWithContentsOfURL:self.traitsURL]) ?: [[NSMutableDictionary alloc] init];
+        _traits = ([[[NSUserDefaults standardUserDefaults] objectForKey:SEGTraitsKey] mutableCopy] ?: [NSMutableDictionary dictionaryWithContentsOfURL:self.traitsURL]) ?: [[NSMutableDictionary alloc] init];
     }
     return _traits;
 }


### PR DESCRIPTION
Queue and Traits properties should return a mutable object. If they are retrieved from NSUserDefaults they are immutable by default, therefore mutableCopy is needed.

I had to downgrade segment pod to the previous version because of this. It was randomly crashing at launch with AppBoy integration.