### PR TITLE
Fix location updates issues

### DIFF
--- a/Pod/Classes/Internal/SEGLocation.h
+++ b/Pod/Classes/Internal/SEGLocation.h
@@ -23,4 +23,6 @@
 @property (nonatomic, copy, readonly) NSDictionary *addressDictionary;
 @property (nonatomic, assign, readonly) BOOL hasKnownLocation;
 
+- (void)startUpdatingLocation;
+
 @end

--- a/Pod/Classes/Internal/SEGSegmentIntegration.m
+++ b/Pod/Classes/Internal/SEGSegmentIntegration.m
@@ -199,7 +199,8 @@ static BOOL GetAdTrackingEnabled()
         network;
     });
 
-    self.location = [self.configuration shouldUseLocationServices] ? [SEGLocation new] : nil;
+    self.location = !self.location ? [self.configuration shouldUseLocationServices] ? [SEGLocation new] : nil : self.location;
+    [self.location startUpdatingLocation];
     if (self.location.hasKnownLocation)
         context[@"location"] = self.location.locationDictionary;
 
@@ -539,7 +540,7 @@ static BOOL GetAdTrackingEnabled()
 - (NSMutableArray *)queue
 {
     if (!_queue) {
-        _queue = ([[NSUserDefaults standardUserDefaults] objectForKey:SEGQueueKey] ?: [NSMutableArray arrayWithContentsOfURL:self.queueURL]) ?: [[NSMutableArray alloc] init];
+        _queue = ([[[NSUserDefaults standardUserDefaults] objectForKey:SEGQueueKey] mutableCopy] ?: [NSMutableArray arrayWithContentsOfURL:self.queueURL]) ?: [[NSMutableArray alloc] init];
     }
     return _queue;
 }
@@ -547,7 +548,7 @@ static BOOL GetAdTrackingEnabled()
 - (NSMutableDictionary *)traits
 {
     if (!_traits) {
-        _traits = ([[NSUserDefaults standardUserDefaults] objectForKey:SEGTraitsKey] ?: [NSMutableDictionary dictionaryWithContentsOfURL:self.traitsURL]) ?: [[NSMutableDictionary alloc] init];
+        _traits = ([[[NSUserDefaults standardUserDefaults] objectForKey:SEGTraitsKey] mutableCopy] ?: [NSMutableDictionary dictionaryWithContentsOfURL:self.traitsURL]) ?: [[NSMutableDictionary alloc] init];
     }
     return _traits;
 }


### PR DESCRIPTION
This PR should address several issues found on version 3.0.4:

- When SEGLocation is initialized from a background thread, it never receives location updates, for this reason I am initializing the locationManager in the main thread.
- SEGSegmentIntegration was initializing SEGLocation every time liveContext method was called (which happens pretty frequently) and shouldUseLocationServices = true. By initializing it all the time we were deallocating the previous instance and allocating a new one and starting the location manager again. This was causing a crash when reverseGeocodeLocation completion handler was called and the syncQueue had already being deallocated. To fix this crash I updated the code to initialize SEGLocation only once.
- SEGLocation->didUpdateLocations was handling location updates without taking into consideration the last time the location was updated. I added code to take location timestamp into consideration and defined LOCATION_AGE (5 min), so any location older than 5 min is automatically discarded.
- There were no calls to stopUpdatingLocation, so once we called startUpdatingLocation we would keep receiving location updates all the time and we would try to reverse geocode all these locations. I noticed that calls to reverse geocode where being made at an approximate rate of 1call/second. In summary this would keep the GPS on and also use network resources to do the reverse geocode. To fix this problem I updated the code to stop getting updates after we get a successful reverse geocode response and we will only process the next location updates after LOCATION_AGE (5 min).
- SEGSegmentIntegration->queue, SEGSegmentIntegration->traits were returning instances of NSArray and NSDictionary instead of their mutable versions. I updated the code to make sure the proper mutable versions are returned. This was causing exceptions while trying to queue a new payload (queuePayload).
