### PR TITLE
Fix crash in SEGAnalytics, func invocationForSelector

### DIFF
--- a/Pod/Classes/SEGAnalytics.m
+++ b/Pod/Classes/SEGAnalytics.m
@@ -520,7 +520,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     invocation.selector = selector;
     for (int i = 0; i < arguments.count; i++) {
-		if (i + 2 <= signature.numberOfArguments) {
+		if (i + 2 < signature.numberOfArguments) {
 			id argument = (arguments[i] == [NSNull null]) ? nil : arguments[i];
 			[invocation setArgument:&argument atIndex:i + 2];
 		}

--- a/Pod/Classes/SEGAnalytics.m
+++ b/Pod/Classes/SEGAnalytics.m
@@ -520,8 +520,10 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     invocation.selector = selector;
     for (int i = 0; i < arguments.count; i++) {
-        id argument = (arguments[i] == [NSNull null]) ? nil : arguments[i];
-        [invocation setArgument:&argument atIndex:i + 2];
+		if (i + 2 <= signature.numberOfArguments) {
+			id argument = (arguments[i] == [NSNull null]) ? nil : arguments[i];
+			[invocation setArgument:&argument atIndex:i + 2];
+		}
     }
     return invocation;
 }


### PR DESCRIPTION
Crashed in SEGAnalytics, func invocationForSelector, [invocation setArgument:&argument atIndex:i + 2], because applicationDidEnterBackground in SEGSegmentIntegration has no one parameter.