### PR TITLE
Added missing initializer in SEGAnalytics.h & fixed return types

### DIFF
--- a/Pod/Classes/SEGAnalytics.h
+++ b/Pod/Classes/SEGAnalytics.h
@@ -56,6 +56,13 @@
 @property (nonatomic, strong, readonly) SEGAnalyticsConfiguration *configuration;
 
 /**
+ * Setup this analytics client instance.
+ *
+ * @param configuration The configuration used to setup the client.
+ */
+- (instancetype)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration;
+
+/**
  * Setup the analytics client.
  *
  * @param configuration The configuration used to setup the client.
@@ -248,7 +255,7 @@
 @interface SEGAnalytics (Deprecated)
 
 + (void)initializeWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use +setupWithConfiguration: instead")));
-- (id)initWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use -initWithConfiguration: instead")));
+- (instancetype)initWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));

--- a/Pod/Classes/SEGAnalytics.m
+++ b/Pod/Classes/SEGAnalytics.m
@@ -30,7 +30,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey];
 }
 
-- (id)initWithWriteKey:(NSString *)writeKey
+- (instancetype)initWithWriteKey:(NSString *)writeKey
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
@@ -91,7 +91,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     });
 }
 
-- (id)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration
+- (instancetype)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration
 {
     NSCParameterAssert(configuration != nil);
 
@@ -573,7 +573,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey]];
 }
 
-- (id)initWithWriteKey:(NSString *)writeKey
+- (instancetype)initWithWriteKey:(NSString *)writeKey
 {
     return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey]];
 }


### PR DESCRIPTION
The initializer `-initWithConfiguration:` is missing in the public header file and thus unusable.
It is referred to by the deprecation message of `-initWithWriteKey:` and must be used when creating a non-singleton instance of `SEGAnalytics`.

This pull request adds it to the public header file.

Also this pull request fixes wrong return types specified for the initializers. 
They now return `instancetype` instead of `id`.