### PR TITLE
Fixed crashes due to NSNotificationCenter observers not being removed

### DIFF
--- a/Pod/Classes/SEGAnalytics.m
+++ b/Pod/Classes/SEGAnalytics.m
@@ -128,6 +128,12 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 }
 
 
+- (void) dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+
 #pragma mark - NSNotificationCenter Callback
 
 


### PR DESCRIPTION
When an `SEGAnalytics` instance gets destroyed the app will crash on certain notifications sent by `NSNotificationCenter` because `SEGAnalytics` never removes itself as an observer.

This pull request properly removes the observers.