### PR TITLE
Fix notification token setting in the segment integration

### DIFF
--- a/Pod/Classes/Internal/SEGSegmentIntegration.m
+++ b/Pod/Classes/Internal/SEGSegmentIntegration.m
@@ -332,7 +332,7 @@ static BOOL GetAdTrackingEnabled()
     [self enqueueAction:@"alias" dictionary:dictionary context:payload.context integrations:payload.integrations];
 }
 
-- (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options
+- (void)registeredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
     NSCParameterAssert(deviceToken != nil);
 


### PR DESCRIPTION
The segment integration is currently using the old-school selector of  registerForRemoteNotificationsWithDeviceToken:options to handle recieving a notification token. Therefore when [SEGAnalytics registeredForRemoteNotificationsWithDeviceToken:] is called, the integration does not receive the forwarded call.

This PR updates the selector to registeredForRemoteNotificationsWithDeviceToken: so that it once again receives the forwarded calls.