### PR TITLE
Fix Build and Version numbers being reversed

### DIFF
--- a/Pod/Classes/SEGAnalytics.m
+++ b/Pod/Classes/SEGAnalytics.m
@@ -153,8 +153,8 @@ NSString *const SEGBuildKey = @"SEGBuildKey";
     NSString *previousVersion = [[NSUserDefaults standardUserDefaults] stringForKey:SEGVersionKey];
     NSInteger previousBuild = [[NSUserDefaults standardUserDefaults] integerForKey:SEGBuildKey];
 
-    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
-    NSInteger currentBuild = [[[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"] integerValue];
+    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+    NSInteger currentBuild = [[[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"] integerValue];
 
     if (!previousBuild) {
         [self track:@"Application Installed" properties:@{


### PR DESCRIPTION
The Bundle IDs are not very clear, `CFBundleVersion` is the build number (as reflected in Xcode under Project -> General -> Identity -> Build), and the `CFBundleShortVersionString` is the marketing version number (Xcode -> Project -> General -> Identity -> Version)