### PR TITLE
Handle root being a navigation controller

### DIFF
--- a/Pod/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Pod/Classes/Internal/UIViewController+SEGScreen.m
@@ -38,37 +38,31 @@
 + (UIViewController *)seg_topViewController
 {
     UIViewController *root = [UIApplication sharedApplication].delegate.window.rootViewController;
-    
-    if ([root isKindOfClass:[UINavigationController class]]) {
-        UIViewController* presented = root.presentedViewController;
-        
-        if (nil == presented) {
-            presented = ((UINavigationController *)root).viewControllers.lastObject;
-        }
-        
-        if (nil != presented) {
-            root = presented;
-        }
-    }
-    
     return [self seg_topViewController:root];
 }
 
 + (UIViewController *)seg_topViewController:(UIViewController *)rootViewController
 {
+    if ([rootViewController isKindOfClass:[UINavigationController class]]) {
+        UIViewController* presented = rootViewController.presentedViewController;
+        
+        if (nil == presented) {
+            presented = ((UINavigationController *)rootViewController).viewControllers.lastObject;
+        }
+        
+        if (nil != presented) {
+            rootViewController = presented;
+        }
+    }
+    
     if (rootViewController.presentedViewController == nil) {
         return rootViewController;
-    }
-
-    if ([rootViewController.presentedViewController isKindOfClass:[UINavigationController class]]) {
-        UINavigationController *navigationController = (UINavigationController *)rootViewController.presentedViewController;
-        UIViewController *lastViewController = [[navigationController viewControllers] lastObject];
-        return [self seg_topViewController:lastViewController];
     }
 
     UIViewController *presentedViewController = (UIViewController *)rootViewController.presentedViewController;
     return [self seg_topViewController:presentedViewController];
 }
+
 
 - (void)seg_viewDidAppear:(BOOL)animated
 {

--- a/Pod/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Pod/Classes/Internal/UIViewController+SEGScreen.m
@@ -38,6 +38,19 @@
 + (UIViewController *)seg_topViewController
 {
     UIViewController *root = [UIApplication sharedApplication].delegate.window.rootViewController;
+    
+    if ([root isKindOfClass:[UINavigationController class]]) {
+        UIViewController* presented = root.presentedViewController;
+        
+        if (nil == presented) {
+            presented = ((UINavigationController *)root).viewControllers.lastObject;
+        }
+        
+        if (nil != presented) {
+            root = presented;
+        }
+    }
+    
     return [self seg_topViewController:root];
 }
 

--- a/Pod/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Pod/Classes/Internal/UIViewController+SEGScreen.m
@@ -44,13 +44,13 @@
 + (UIViewController *)seg_topViewController:(UIViewController *)rootViewController
 {
     if ([rootViewController isKindOfClass:[UINavigationController class]]) {
-        UIViewController* presented = rootViewController.presentedViewController;
+        UIViewController *presented = rootViewController.presentedViewController;
         
-        if (nil == presented) {
+        if (presented == nil) {
             presented = ((UINavigationController *)rootViewController).viewControllers.lastObject;
         }
         
-        if (nil != presented) {
+        if (presented != nil) {
             rootViewController = presented;
         }
     }


### PR DESCRIPTION
The automatic screen event code did not handle the case where the root view controller was a UINavigationController.

The code would often just report the top level Nav as it would not always have a presented VC.

This proposed change checks for a top level nav controller, and steps into either it's presented controller or it's last in the list of view controllers as appropriate.