### PR TITLE
Handle root being a navigation controller

### DIFF
--- a/Pod/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Pod/Classes/Internal/UIViewController+SEGScreen.m
@@ -44,24 +44,24 @@
 
 + (UIViewController *)seg_topViewController:(UIViewController *)rootViewController
 {
-    if (rootViewController.presentedViewController == nil) {
-        return rootViewController;
+    UIViewController *presentedViewController = rootViewController.presentedViewController;
+    if (presentedViewController != nil) {
+        return [self seg_topViewController:presentedViewController];
     }
 
-    if ([rootViewController.presentedViewController isKindOfClass:[UINavigationController class]]) {
-        UINavigationController *navigationController = (UINavigationController *)rootViewController.presentedViewController;
-        UIViewController *lastViewController = [[navigationController viewControllers] lastObject];
+    if ([rootViewController isKindOfClass:[UINavigationController class]]) {
+        UIViewController *lastViewController = [[(UINavigationController *)rootViewController viewControllers] lastObject];
         return [self seg_topViewController:lastViewController];
     }
 
-    UIViewController *presentedViewController = (UIViewController *)rootViewController.presentedViewController;
-    return [self seg_topViewController:presentedViewController];
+    return rootViewController;
 }
 
 - (void)seg_viewDidAppear:(BOOL)animated
 {
     UIViewController *top = [UIViewController seg_topViewController];
     if (!top) {
+        SEGLog(@"Could not infer screen.");
         return;
     }
 


### PR DESCRIPTION
The automatic screen event code did not handle the case where the root view controller was a UINavigationController.

The code would often just report the top level Nav as it would not always have a presented VC.

This proposed change checks for a top level nav controller, and steps into either it's presented controller or it's last in the list of view controllers as appropriate.

Closes #542 and #543 

cc @voidref 