### PR TITLE
Fixed analyzer warnings

### DIFF
--- a/Pod/Classes/Internal/SEGReachability.m
+++ b/Pod/Classes/Internal/SEGReachability.m
@@ -113,6 +113,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithName(NULL, [hostname UTF8String]);
     if (ref) {
         id reachability = [[self alloc] initWithReachabilityRef:ref];
+		CFRelease(ref);
 
 #if __has_feature(objc_arc)
         return reachability;
@@ -129,6 +130,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *)hostAddress);
     if (ref) {
         id reachability = [[self alloc] initWithReachabilityRef:ref];
+		CFRelease(ref);
 
 #if __has_feature(objc_arc)
         return reachability;
@@ -171,6 +173,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     if (self != nil) {
         self.reachableOnWWAN = YES;
         self.reachabilityRef = ref;
+		CFRetain(self.reachabilityRef);
     }
 
     return self;


### PR DESCRIPTION
This fixes a warning produced by the static analyzer.
Closes #517 and #514 

Just a rebase + against `dev`.