### PR TITLE
Fix for when a title may come back as empty string

### DIFF
--- a/Pod/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Pod/Classes/Internal/UIViewController+SEGScreen.m
@@ -66,7 +66,7 @@
     }
 
     NSString *name = [top title];
-    if (!name) {
+    if (name.length == 0) {
         name = [[[top class] description] stringByReplacingOccurrencesOfString:@"ViewController" withString:@""];
         // Class name could be just "ViewController".
         if (name.length == 0) {


### PR DESCRIPTION
There are scenarios that an alert view controller for instance could be displayed without specifying a title.  In that instance the screenTitle.length > 0 assertion would fail.

This fix simply checks that name.length == 0 and if it is then try and generate a useful name.