### PR TITLE
Replace Foundation import with UIKit import

### DIFF
--- a/Analytics/Classes/Internal/UIViewController+SEGScreen.h
+++ b/Analytics/Classes/Internal/UIViewController+SEGScreen.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
 @interface UIViewController (SEGScreen)


### PR DESCRIPTION
We were integrating this library using GYP instead of CocoaPods and there was a compilation issue because `UIViewController` is defined in `UIKit` rather than `Foundation`.