### PR TITLE
correctly skip forwarding disabled events in the tracking plan

### DIFF
--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -559,7 +559,8 @@ NSString *const SEGBuildKey = @"SEGBuildKey";
 
     NSString *eventType = NSStringFromSelector(selector);
     if ([eventType hasPrefix:@"track:"]) {
-        BOOL enabled = [self isTrackEvent:arguments[0] enabledForIntegration:key inPlan:self.cachedSettings[@"plan"]];
+        SEGTrackPayload *eventPayload = arguments[0];
+        BOOL enabled = [self isTrackEvent:eventPayload.event enabledForIntegration:key inPlan:self.cachedSettings[@"plan"]];
         if (!enabled) {
             SEGLog(@"Not sending call to %@ because it is disabled in plan.", key);
             return;


### PR DESCRIPTION
Previously events that were marked as disabled in the tracking plan
would still be sent to Segment (and other integrations, both client side
and server side).

The bug was that we were accidentally checking the class name of the
SEGTrackPayload instead of the `event` in the payload.