### PR TITLE
Fixed crash due to the referrer dictionary being `assign`

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -69,7 +69,7 @@ static BOOL GetAdTrackingEnabled()
 @property (nonatomic, strong) NSMutableDictionary *traits;
 @property (nonatomic, assign) SEGAnalytics *analytics;
 @property (nonatomic, assign) SEGAnalyticsConfiguration *configuration;
-@property (nonatomic, assign) NSDictionary *referrer;
+@property (nonatomic, copy) NSDictionary *referrer;
 @property (nonatomic, copy) NSString *userId;
 @property (nonatomic, strong) NSURL *apiURL;
 @property (nonatomic, strong) SEGHTTPClient *httpClient;


### PR DESCRIPTION
`assign` is a synonym for `unsafe_unretained` in ARC, so if the dictionary is released the pointer points to a deallocated object and the app will crash when it is used!