### PR TITLE
Re-dispatch callbacks from SEGHTTPClient onto correct queues before executing logic

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -15,6 +15,8 @@
  * This method will convert the dictionary to json, gzip it and upload the data.
  * It will respond with retry = YES if the batch should be reuploaded at a later time.
  * It will ask to retry for json errors and 3xx/5xx codes, and not retry for 2xx/4xx response codes.
+ * NOTE: You need to re-dispatch within the completionHandler onto a desired queue to avoid threading issues.
+ * Completion handlers are called on a dispatch queue internal to SEGHTTPClient. 
  */
 - (NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler;
 

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -537,17 +537,19 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     SEGLog(@"%@ Flushing %lu of %lu queued API calls.", self, (unsigned long)batch.count, (unsigned long)self.queue.count);
     SEGLog(@"Flushing batch %@.", payload);
 
-    self.batchRequest = [self.analytics.httpClient upload:payload forWriteKey:self.configuration.writeKey completionHandler:^(BOOL retry) {
-        if (retry) {
-            [self notifyForName:SEGSegmentRequestDidFailNotification userInfo:batch];
+    self.batchRequest = [self.httpClient upload:payload forWriteKey:self.configuration.writeKey completionHandler:^(BOOL retry) {
+        [self dispatchBackground:^{
+            if (retry) {
+                [self notifyForName:SEGSegmentRequestDidFailNotification userInfo:batch];
+                self.batchRequest = nil;
+                return;
+            }
+            
+            [self.queue removeObjectsInArray:batch];
+            [self persistQueue];
+            [self notifyForName:SEGSegmentRequestDidSucceedNotification userInfo:batch];
             self.batchRequest = nil;
-            return;
-        }
-
-        [self.queue removeObjectsInArray:batch];
-        [self persistQueue];
-        [self notifyForName:SEGSegmentRequestDidSucceedNotification userInfo:batch];
-        self.batchRequest = nil;
+        }];
     }];
 
     [self notifyForName:SEGSegmentDidSendRequestNotification userInfo:batch];
@@ -637,12 +639,13 @@ NSString *const SEGTrackedAttributionKey = @"SEGTrackedAttributionKey";
     [context addEntriesFromDictionary:liveContext];
 
     self.attributionRequest = [self.httpClient attributionWithWriteKey:self.configuration.writeKey forDevice:[context copy] completionHandler:^(BOOL success, NSDictionary *properties) {
-        if (success) {
-            [self.analytics track:@"Install Attributed" properties:properties];
-            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:SEGTrackedAttributionKey];
-        }
-
-        self.attributionRequest = nil;
+        [self dispatchBackground:^{
+            if (success) {
+                [self.analytics track:@"Install Attributed" properties:properties];
+                [[NSUserDefaults standardUserDefaults] setBool:YES forKey:SEGTrackedAttributionKey];
+            }
+            self.attributionRequest = nil;
+        }];
     }];
 #endif
 }

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -560,11 +560,12 @@ NSString *const SEGBuildKey = @"SEGBuildKey";
     }
 
     self.settingsRequest = [self.httpClient settingsForWriteKey:self.configuration.writeKey completionHandler:^(BOOL success, NSDictionary *settings) {
-        if (success) {
-            [self setCachedSettings:settings];
-        }
-
-        self.settingsRequest = nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (success) {
+                [self setCachedSettings:settings];
+            }
+            self.settingsRequest = nil;
+        });
     }];
 }
 


### PR DESCRIPTION
Likely should help fix issue. 

https://segment.atlassian.net/browse/EPD-142
https://segment.atlassian.net/browse/EPD-198

In a separate (not hot fix PR) we should make it easier to have correct threading logic
by letting `SEGHTTPClient` take in a dispatch queue upon initialization

cc @f2prateek @ladanazita 
