### PR TITLE
End background tasks as soon as flushing is complete.

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -471,7 +471,6 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         }
         if (self.batchRequest != nil) {
             SEGLog(@"%@ API request already in progress, not flushing again.", self);
-            [self endBackgroundTask];
             return;
         }
 

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -539,6 +539,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         if (retry) {
             [self notifyForName:SEGSegmentRequestDidFailNotification userInfo:batch];
             self.batchRequest = nil;
+            [self endBackgroundTask];
             return;
         }
 

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -466,10 +466,12 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     [self dispatchBackground:^{
         if ([self.queue count] == 0) {
             SEGLog(@"%@ No queued API calls to flush.", self);
+            [self endBackgroundTask];
             return;
         }
         if (self.batchRequest != nil) {
             SEGLog(@"%@ API request already in progress, not flushing again.", self);
+            [self endBackgroundTask];
             return;
         }
 
@@ -544,6 +546,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         [self persistQueue];
         [self notifyForName:SEGSegmentRequestDidSucceedNotification userInfo:batch];
         self.batchRequest = nil;
+        [self endBackgroundTask];
     }];
 
     [self notifyForName:SEGSegmentDidSendRequestNotification userInfo:batch];


### PR DESCRIPTION
This fixes what I consider to be a critical bug, reproducible in the Example app.

`SEGSegmentIntegration` currently does not call `UIApplication#endBackgroundTask` until the expiration handler from `beginBackgroundTask` is called, which means the app will remaining running open in the background until the expiration handler is called. `SEGSegmentIntegration` should behave as a good citizen and end the background task as soon as it no longer needs.

To reproduce:
1. Run the Example app in the debugger
2. Press Command-Shift-H to background the app without killing its process.
3. Pause the debugger and type in `po [(UIApplication*)[UIApplication sharedApplication] backgroundTimeRemaining]`
4. Note the result is a large number over 100, indicating the app will remain active for several minutes.

This change fixes it by calling `endBackgroundTask` from the three locations in the path taken after backgrounding the app. After making the change, the result of the print out from step 3 above is `1.7976931348623157E+308`, indicating the app has been suspended.