### PR TITLE
Workaround to handle IOS 8.3 bug where Content-type of application/x-…

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -47,6 +47,7 @@
 
     NSURL *url = [SEGMENT_API_BASE URLByAppendingPathComponent:@"batch"];
     NSMutableURLRequest *request = self.requestFactory(url);
+    [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request setHTTPMethod:@"POST"];
 
     NSError *error = nil;


### PR DESCRIPTION
A workaround for an IOS 8.3 issue that was causing POSTs to api.segment.io to be made with Content-type of application/x-www-form-urlencoded; instead of application/json. 