### PR TITLE
Fall back to using Segment integration when we cannot get settings

### DIFF
--- a/Analytics.podspec
+++ b/Analytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Analytics"
-  s.version          = "3.5.3"
+  s.version          = "3.5.4"
   s.summary          = "The hassle-free way to add analytics to your iOS app."
 
   s.description      = <<-DESC

--- a/Analytics.podspec
+++ b/Analytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Analytics"
-  s.version          = "3.5.4"
+  s.version          = "3.5.3"
   s.summary          = "The hassle-free way to add analytics to your iOS app."
 
   s.description      = <<-DESC

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -563,7 +563,7 @@ NSString *const SEGBuildKey = @"SEGBuildKey";
         if (success) {
             [self setCachedSettings:settings];
         } else {
-            // Hotfix: If settings request fail, fall back to using just Segment integration
+            // TODO: If settings request fail, fall back to using just Segment integration
             // Won't catch situation where this callback never gets called - that will get addressed separately in regular dev 
             [self setCachedSettings:@{
                 @"integrations": @{
@@ -591,7 +591,7 @@ NSString *const SEGBuildKey = @"SEGBuildKey";
 
 + (NSString *)version
 {
-    return @"3.5.4";
+    return @"3.5.3";
 }
 
 #pragma mark - Private

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -591,7 +591,7 @@ NSString *const SEGBuildKey = @"SEGBuildKey";
 
 + (NSString *)version
 {
-    return @"3.5.3";
+    return @"3.5.4";
 }
 
 #pragma mark - Private

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -562,8 +562,16 @@ NSString *const SEGBuildKey = @"SEGBuildKey";
     self.settingsRequest = [self.httpClient settingsForWriteKey:self.configuration.writeKey completionHandler:^(BOOL success, NSDictionary *settings) {
         if (success) {
             [self setCachedSettings:settings];
+        } else {
+            // Hotfix: If settings request fail, fall back to using just Segment integration
+            // Won't catch situation where this callback never gets called - that will get addressed separately in regular dev 
+            [self setCachedSettings:@{
+                @"integrations": @{
+                    @"Segment.io": @{ @"apiKey": self.configuration.writeKey },
+                },
+                @"plan": @{ @"track": @{} }
+            }];
         }
-
         self.settingsRequest = nil;
     }];
 }


### PR DESCRIPTION
cc @f2prateek @ladanazita 

To repro the original buggy behavior
1) Put device in airplane mode and open app
2) Send an event `Application Launched 1`
3) Force kill the app via task switcher
4) Disable airplane mode and regain internet access
5) Launch the app again, send another event `Application Launched 2`
6) Observe that `Application Launched 2` will hit tracking API, while `Application Launched 1` will be missing. 

Basically what happens is that during step 2, if the settings request were to fail, no integrations would be initialized (segment included). This hotfix falls back to segment integration in those cases and we'll have a more comprehensive set of fixes to address this from a design level in development branch.