### PR TITLE
Ensure network.carrier is populated.

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -114,8 +114,9 @@ static BOOL GetAdTrackingEnabled()
     }
     return self;
 }
-    
-- (void)setupFlushTimer {
+
+- (void)setupFlushTimer
+{
     self.flushTimer = [NSTimer scheduledTimerWithTimeInterval:30.0 target:self selector:@selector(flush) userInfo:nil repeats:YES];
 }
 
@@ -174,17 +175,6 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         @"version" : device.systemVersion
     };
 
-#if TARGET_OS_IOS
-    static dispatch_once_t networkInfoOnceToken;
-    dispatch_once(&networkInfoOnceToken, ^{
-        _telephonyNetworkInfo = [[CTTelephonyNetworkInfo alloc] init];
-    });
-
-    CTCarrier *carrier = [_telephonyNetworkInfo subscriberCellularProvider];
-    if (carrier.carrierName.length)
-        dict[@"network"] = @{ @"carrier" : carrier.carrierName };
-#endif
-
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
     dict[@"screen"] = @{
         @"width" : @(screenSize.width),
@@ -231,6 +221,17 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
             network[@"wifi"] = @(self.reachability.isReachableViaWiFi);
             network[@"cellular"] = @(self.reachability.isReachableViaWWAN);
         }
+
+#if TARGET_OS_IOS
+        static dispatch_once_t networkInfoOnceToken;
+        dispatch_once(&networkInfoOnceToken, ^{
+            _telephonyNetworkInfo = [[CTTelephonyNetworkInfo alloc] init];
+        });
+
+        CTCarrier *carrier = [_telephonyNetworkInfo subscriberCellularProvider];
+        if (carrier.carrierName.length)
+            network[@"carrier"] = carrier.carrierName;
+#endif
 
         network;
     });
@@ -542,7 +543,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
                 [self endBackgroundTask];
                 return;
             }
-            
+
             [self.queue removeObjectsInArray:batch];
             [self persistQueue];
             [self notifyForName:SEGSegmentRequestDidSucceedNotification userInfo:batch];


### PR DESCRIPTION
Previously liveContext would populate `network.cellular` and
`network.wifi`, whilc staticContext would populate `network.carrier`.

In merging the two, the `network` dictionary in liveContext would
override the one in staticContext, causing `network.carrier` to be
ignored in the merged dictionary.

For now, we're populating the `network.carrier` as part of liveContext
to avoid this conflict.

Another potential fix would be to do a deep merge instead of shallow merge so
that `network.carrier` is preserved. However this would also apply to
custom context dictionaries sent by customers, and might not be the
behaviour they want (e.g. if they sent `context.network` as `{}`, the
deep merge would preserve the fields we collect, while a shallow merge
would ignore it).