### PR TITLE
Relax patch coverage requirements

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,8 +16,7 @@ coverage:
         threshold: 5
     patch:
       default:
-        target: auto
-        threshold: 5
+        enabled: no
     changes: false
 
 comment:


### PR DESCRIPTION
For certain changes we don't always need the individual patch to meet requirement as long as the overall codebase meets coverage requirements.