### PR TITLE
fix: transaction.transactionIdentifier is nullable, letting it throug…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Analytics is available through [CocoaPods](http://cocoapods.org) and [Carthage](
 ### CocoaPods
 
 ```ruby
-pod "Analytics", "3.6.0-beta"
+pod "Analytics", "3.6.0-rc"
 ```
 
 If you'd rather have a version that lags behind but has been field tested longer, you may use


### PR DESCRIPTION
…h will crash the App in those cases where it is nil

According to Apple’s documentation (https://developer.apple.com/reference/storekit/skpaymenttransaction) the transactionIdentifier attribute is nullable. It is not clear under which circumstances a successful transaction will not have an identifier, but Apple’s overview of its APIs has determined that this is possible and we have tracked crashes linked to this condition in Crashlytics (http://crashes.to/s/8c3d076840e)

We cannot know if Segment would rather mark these transactions with a self-made identifiers or drop them, we assume that invalid transactions should not be tracked as they cannot be linked to records in other databases without this ID.