### PR TITLE
fix: transaction.transactionIdentifier is nullable

### DIFF
--- a/Analytics/Classes/Internal/SEGStoreKitTracker.m
+++ b/Analytics/Classes/Internal/SEGStoreKitTracker.m
@@ -70,6 +70,10 @@
 #pragma mark - Track
 - (void)trackTransaction:(SKPaymentTransaction *)transaction forProduct:(SKProduct *)product
 {
+    if (transaction.transactionIdentifier == nil) {
+        return;
+    }
+
     NSString *currency = [product.priceLocale objectForKey:NSLocaleCurrencyCode];
 
     [self.analytics track:@"Order Completed" properties:@{

--- a/Analytics/Classes/Internal/SEGStoreKitTracker.m
+++ b/Analytics/Classes/Internal/SEGStoreKitTracker.m
@@ -70,6 +70,9 @@
 #pragma mark - Track
 - (void)trackTransaction:(SKPaymentTransaction *)transaction forProduct:(SKProduct *)product
 {
+    // it seems the identifier is nil for renewable subscriptions
+    // see http://stackoverflow.com/questions/14827059/skpaymenttransactions-originaltransaction-transactionreceipt-nil-for-restore-on
+    // there isn't a spec'd event for this case ( https://segment.com/docs/spec/ecommerce/v2/ ) so ignoring it for now
     if (transaction.transactionIdentifier == nil) {
         return;
     }


### PR DESCRIPTION
-- resubmission of pull request: https://github.com/segmentio/analytics-ios/pull/667
It isn't clear to me how to rebase within the context of a pull request so I created a new pull request that follows your contribution guidelines (opened against the dev branch).

I tweaked the change, I opted to modify the trackTransaction:forProduct: method with a "guard" statement because at this point in the code it is clear why we should not allow a nil value through.

----

According to Apple’s documentation (https://developer.apple.com/reference/storekit/skpaymenttransaction) the transactionIdentifier attribute can be nil.

Trying to create a dictionary with a nil value leads to a crash, and we’ve seen this type of crash in production (http://crashes.to/s/8c3d076840e). The nil value would be used with the keys “orderId” and “sku”.