### PR TITLE
Pass through userInfo

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -520,7 +520,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 - (void)notifyForName:(NSString *)name userInfo:(id)userInfo
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:name object:self];
+        [[NSNotificationCenter defaultCenter] postNotificationName:name object:userInfo];
         SEGLog(@"sent notification %@", name);
     });
 }


### PR DESCRIPTION
Any reason you are not passing the userInfo that is received to the notification? But instead passing self which properties are mostly private and therefor not accessible.