### PR TITLE
Fix application opened

### DIFF
--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -49,21 +49,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Associate a user with their unique ID and record traits about them.
- 
+
  @param userId        A database ID (or email address) for this user. If you don't have a userId
  but want to record traits, you should pass nil. For more information on how we
  generate the UUID and Apple's policies on IDs, see https://segment.io/libraries/ios#ids
- 
+
  @param traits        A dictionary of traits you know about the user. Things like: email, name, plan, etc.
- 
+
  @param options       A dictionary of options, such as the `@"anonymousId"` key. If no anonymous ID is specified one will be generated for you.
- 
+
  @discussion
  When you learn more about who your user is, you can record that information with identify.
- 
+
  */
 - (void)identify:(NSString *)userId traits:(SERIALIZABLE_DICT _Nullable)traits options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)identify:(NSString *)userId traits:(SERIALIZABLE_DICT _Nullable)traits;
@@ -72,19 +72,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Record the actions your users perform.
- 
+
  @param event         The name of the event you're tracking. We recommend using human-readable names
  like `Played a Song` or `Updated Status`.
- 
+
  @param properties    A dictionary of properties for the event. If the event was 'Added to Shopping Cart', it might
  have properties like price, productType, etc.
- 
+
  @discussion
  When a user performs an action in your app, you'll want to track that action for later analysis. Use the event name to say what the user did, and properties to specify any interesting details of the action.
- 
+
  */
 - (void)track:(NSString *)event properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)track:(NSString *)event properties:(SERIALIZABLE_DICT _Nullable)properties;
@@ -92,19 +92,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Record the screens or views your users see.
- 
+
  @param screenTitle   The title of the screen being viewed. We recommend using human-readable names
  like 'Photo Feed' or 'Completed Purchase Screen'.
- 
+
  @param properties    A dictionary of properties for the screen view event. If the event was 'Added to Shopping Cart',
  it might have properties like price, productType, etc.
- 
+
  @discussion
  When a user views a screen in your app, you'll want to record that here. For some tools like Google Analytics and Flurry, screen views are treated specially, and are different from "events" kind of like "page views" on the web. For services that don't treat "screen views" specially, we map "screen" straight to "track" with the same parameters. For example, Mixpanel doesn't treat "screen views" any differently. So a call to "screen" will be tracked as a normal event in Mixpanel, but get sent to Google Analytics and Flurry as a "screen".
- 
+
  */
 - (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties;
@@ -112,16 +112,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Associate a user with a group, organization, company, project, or w/e *you* call them.
- 
+
  @param groupId       A database ID for this group.
  @param traits        A dictionary of traits you know about the group. Things like: name, employees, etc.
- 
+
  @discussion
  When you learn more about who the group is, you can record that information with group.
- 
+
  */
 - (void)group:(NSString *)groupId traits:(SERIALIZABLE_DICT _Nullable)traits options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)group:(NSString *)groupId traits:(SERIALIZABLE_DICT _Nullable)traits;
@@ -129,17 +129,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Merge two user identities, effectively connecting two sets of user data as one.
  This may not be supported by all integrations.
- 
+
  @param newId         The new ID you want to alias the existing ID to. The existing ID will be either the
  previousId if you have called identify, or the anonymous ID.
- 
+
  @discussion
  When you learn more about who the group is, you can record that information with group.
- 
+
  */
 - (void)alias:(NSString *)newId options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)alias:(NSString *)newId;
@@ -154,10 +154,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Trigger an upload of all queued events.
- 
+
  @discussion
  This is useful when you want to force all messages queued on the device to be uploaded. Please note that not all integrations
  respond to this method.
@@ -166,10 +166,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Reset any user state that is cached on the device.
- 
+
  @discussion
  This is useful when a user logs out and you want to clear the identity. It will clear any
  traits or userId's cached on the device.
@@ -178,10 +178,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Enable the sending of analytics data. Enabled by default.
- 
+
  @discussion
  Occasionally used in conjunction with disable user opt-out handling.
  */
@@ -190,10 +190,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
- 
+
  @abstract
  Completely disable the sending of any analytics data.
- 
+
  @discussion
  If have a way for users to actively or passively (sometimes based on location) opt-out of
  analytics data collection, you can use this method to turn off all data collection.

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -49,21 +49,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Associate a user with their unique ID and record traits about them.
-
+ 
  @param userId        A database ID (or email address) for this user. If you don't have a userId
  but want to record traits, you should pass nil. For more information on how we
  generate the UUID and Apple's policies on IDs, see https://segment.io/libraries/ios#ids
-
+ 
  @param traits        A dictionary of traits you know about the user. Things like: email, name, plan, etc.
-
+ 
  @param options       A dictionary of options, such as the `@"anonymousId"` key. If no anonymous ID is specified one will be generated for you.
-
+ 
  @discussion
  When you learn more about who your user is, you can record that information with identify.
-
+ 
  */
 - (void)identify:(NSString *)userId traits:(SERIALIZABLE_DICT _Nullable)traits options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)identify:(NSString *)userId traits:(SERIALIZABLE_DICT _Nullable)traits;
@@ -72,19 +72,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Record the actions your users perform.
-
+ 
  @param event         The name of the event you're tracking. We recommend using human-readable names
  like `Played a Song` or `Updated Status`.
-
+ 
  @param properties    A dictionary of properties for the event. If the event was 'Added to Shopping Cart', it might
  have properties like price, productType, etc.
-
+ 
  @discussion
  When a user performs an action in your app, you'll want to track that action for later analysis. Use the event name to say what the user did, and properties to specify any interesting details of the action.
-
+ 
  */
 - (void)track:(NSString *)event properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)track:(NSString *)event properties:(SERIALIZABLE_DICT _Nullable)properties;
@@ -92,19 +92,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Record the screens or views your users see.
-
+ 
  @param screenTitle   The title of the screen being viewed. We recommend using human-readable names
  like 'Photo Feed' or 'Completed Purchase Screen'.
-
+ 
  @param properties    A dictionary of properties for the screen view event. If the event was 'Added to Shopping Cart',
  it might have properties like price, productType, etc.
-
+ 
  @discussion
  When a user views a screen in your app, you'll want to record that here. For some tools like Google Analytics and Flurry, screen views are treated specially, and are different from "events" kind of like "page views" on the web. For services that don't treat "screen views" specially, we map "screen" straight to "track" with the same parameters. For example, Mixpanel doesn't treat "screen views" any differently. So a call to "screen" will be tracked as a normal event in Mixpanel, but get sent to Google Analytics and Flurry as a "screen".
-
+ 
  */
 - (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties;
@@ -112,16 +112,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Associate a user with a group, organization, company, project, or w/e *you* call them.
-
+ 
  @param groupId       A database ID for this group.
  @param traits        A dictionary of traits you know about the group. Things like: name, employees, etc.
-
+ 
  @discussion
  When you learn more about who the group is, you can record that information with group.
-
+ 
  */
 - (void)group:(NSString *)groupId traits:(SERIALIZABLE_DICT _Nullable)traits options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)group:(NSString *)groupId traits:(SERIALIZABLE_DICT _Nullable)traits;
@@ -129,17 +129,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Merge two user identities, effectively connecting two sets of user data as one.
  This may not be supported by all integrations.
-
+ 
  @param newId         The new ID you want to alias the existing ID to. The existing ID will be either the
  previousId if you have called identify, or the anonymous ID.
-
+ 
  @discussion
  When you learn more about who the group is, you can record that information with group.
-
+ 
  */
 - (void)alias:(NSString *)newId options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)alias:(NSString *)newId;
@@ -154,10 +154,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Trigger an upload of all queued events.
-
+ 
  @discussion
  This is useful when you want to force all messages queued on the device to be uploaded. Please note that not all integrations
  respond to this method.
@@ -166,10 +166,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Reset any user state that is cached on the device.
-
+ 
  @discussion
  This is useful when a user logs out and you want to clear the identity. It will clear any
  traits or userId's cached on the device.
@@ -178,10 +178,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Enable the sending of analytics data. Enabled by default.
-
+ 
  @discussion
  Occasionally used in conjunction with disable user opt-out handling.
  */
@@ -190,10 +190,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @method
-
+ 
  @abstract
  Completely disable the sending of any analytics data.
-
+ 
  @discussion
  If have a way for users to actively or passively (sometimes based on location) opt-out of
  analytics data collection, you can use this method to turn off all data collection.

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -42,21 +42,21 @@ static SEGAnalytics *__sharedInstance = nil;
 - (instancetype)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration
 {
     NSCParameterAssert(configuration != nil);
-    
+
     if (self = [self init]) {
         self.configuration = configuration;
         self.enabled = YES;
-        
+
         // In swift this would not have been OK... But hey.. It's objc
         // TODO: Figure out if this is really the best way to do things here.
         self.integrationsManager = [[SEGIntegrationsManager alloc] initWithAnalytics:self];
         
         self.runner = [[SEGMiddlewareRunner alloc] initWithMiddlewares:
                        [configuration.middlewares ?: @[] arrayByAddingObject:self.integrationsManager]];
-        
+
         // Attach to application state change hooks
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-        
+
         // Pass through for application state change events
         for (NSString *name in @[ UIApplicationDidEnterBackgroundNotification,
                                   UIApplicationDidFinishLaunchingNotification,
@@ -66,14 +66,14 @@ static SEGAnalytics *__sharedInstance = nil;
                                   UIApplicationDidBecomeActiveNotification ]) {
             [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:nil];
         }
-        
+
         if (configuration.recordScreenViews) {
             [UIViewController seg_swizzleViewDidAppear];
         }
         if (configuration.trackInAppPurchases) {
             _storeKitTracker = [SEGStoreKitTracker trackTransactionsForAnalytics:self];
         }
-        
+
 #if !TARGET_OS_TV
         if (configuration.trackPushNotifications && configuration.launchOptions) {
             NSDictionary *remoteNotification = configuration.launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
@@ -114,43 +114,43 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     if (!self.configuration.trackApplicationLifecycleEvents) {
         return;
     }
-    // Previously SEGBuildKey was stored an integer. This was incorrect because the CFBundleVersion
+        // Previously SEGBuildKey was stored an integer. This was incorrect because the CFBundleVersion
     // can be a string. This migrates SEGBuildKey to be stored as a string.
     NSInteger previousBuildV1 = [[NSUserDefaults standardUserDefaults] integerForKey:SEGBuildKeyV1];
     if (previousBuildV1) {
         [[NSUserDefaults standardUserDefaults] setObject:[@(previousBuildV1) stringValue] forKey:SEGBuildKeyV2];
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:SEGBuildKeyV1];
     }
-    
+
     NSString *previousVersion = [[NSUserDefaults standardUserDefaults] stringForKey:SEGVersionKey];
     NSString *previousBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:SEGBuildKeyV2];
-    
+
     NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
-    
+
     if (!previousBuildV2) {
         [self track:@"Application Installed" properties:@{
-                                                          @"version" : currentVersion,
-                                                          @"build" : currentBuild
-                                                          }];
+            @"version" : currentVersion,
+            @"build" : currentBuild
+        }];
     } else if (currentBuild != previousBuildV2) {
         [self track:@"Application Updated" properties:@{
-                                                        @"previous_version" : previousVersion,
-                                                        @"previous_build" : previousBuildV2,
-                                                        @"version" : currentVersion,
-                                                        @"build" : currentBuild
-                                                        }];
+            @"previous_version" : previousVersion,
+            @"previous_build" : previousBuildV2,
+            @"version" : currentVersion,
+            @"build" : currentBuild
+        }];
     }
     
     [self track:@"Application Opened" properties:@{
-                                                   @"from_background": @NO,
-                                                   @"version" : currentVersion,
-                                                   @"build" : currentBuild,
-                                                   @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
-                                                   @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
-                                                   }];
-    
-    
+        @"from_background": @NO,
+        @"version" : currentVersion,
+        @"build" : currentBuild,
+        @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
+        @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
+    }];
+
+
     [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];
     [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:SEGBuildKeyV2];
     
@@ -164,10 +164,10 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
     [self track:@"Application Opened" properties:@{
-                                                   @"from_background": @YES,
-                                                   @"version" : currentVersion,
-                                                   @"build" : currentBuild,
-                                                   }];
+        @"from_background": @YES,
+        @"version" : currentVersion,
+        @"build" : currentBuild,
+    }];
 }
 
 
@@ -194,11 +194,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 {
     NSCAssert2(userId.length > 0 || traits.count > 0, @"either userId (%@) or traits (%@) must be provided.", userId, traits);
     [self run:SEGEventTypeIdentify payload:
-     [[SEGIdentifyPayload alloc] initWithUserId:userId
-                                    anonymousId:nil
-                                         traits:SEGCoerceDictionary(traits)
-                                        context:SEGCoerceDictionary([options objectForKey:@"context"])
-                                   integrations:[options objectForKey:@"integrations"]]];
+                                       [[SEGIdentifyPayload alloc] initWithUserId:userId
+                                                                      anonymousId:nil
+                                                                           traits:SEGCoerceDictionary(traits)
+                                                                          context:SEGCoerceDictionary([options objectForKey:@"context"])
+                                                                     integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Track
@@ -217,10 +217,10 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 {
     NSCAssert1(event.length > 0, @"event (%@) must not be empty.", event);
     [self run:SEGEventTypeTrack payload:
-     [[SEGTrackPayload alloc] initWithEvent:event
-                                 properties:SEGCoerceDictionary(properties)
-                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
-                               integrations:[options objectForKey:@"integrations"]]];
+                                    [[SEGTrackPayload alloc] initWithEvent:event
+                                                                properties:SEGCoerceDictionary(properties)
+                                                                   context:SEGCoerceDictionary([options objectForKey:@"context"])
+                                                              integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Screen
@@ -238,12 +238,12 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 - (void)screen:(NSString *)screenTitle properties:(NSDictionary *)properties options:(NSDictionary *)options
 {
     NSCAssert1(screenTitle.length > 0, @"screen name (%@) must not be empty.", screenTitle);
-    
+
     [self run:SEGEventTypeScreen payload:
-     [[SEGScreenPayload alloc] initWithName:screenTitle
-                                 properties:SEGCoerceDictionary(properties)
-                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
-                               integrations:[options objectForKey:@"integrations"]]];
+                                     [[SEGScreenPayload alloc] initWithName:screenTitle
+                                                                 properties:SEGCoerceDictionary(properties)
+                                                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
+                                                               integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Group
@@ -261,10 +261,10 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 - (void)group:(NSString *)groupId traits:(NSDictionary *)traits options:(NSDictionary *)options
 {
     [self run:SEGEventTypeGroup payload:
-     [[SEGGroupPayload alloc] initWithGroupId:groupId
-                                       traits:SEGCoerceDictionary(traits)
-                                      context:SEGCoerceDictionary([options objectForKey:@"context"])
-                                 integrations:[options objectForKey:@"integrations"]]];
+                                    [[SEGGroupPayload alloc] initWithGroupId:groupId
+                                                                      traits:SEGCoerceDictionary(traits)
+                                                                     context:SEGCoerceDictionary([options objectForKey:@"context"])
+                                                                integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Alias
@@ -277,9 +277,9 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 - (void)alias:(NSString *)newId options:(NSDictionary *)options
 {
     [self run:SEGEventTypeAlias payload:
-     [[SEGAliasPayload alloc] initWithNewId:newId
-                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
-                               integrations:[options objectForKey:@"integrations"]]];
+                                    [[SEGAliasPayload alloc] initWithNewId:newId
+                                                                   context:SEGCoerceDictionary([options objectForKey:@"context"])
+                                                              integrations:[options objectForKey:@"integrations"]]];
 }
 
 - (void)trackPushNotification:(NSDictionary *)properties fromLaunch:(BOOL)launch
@@ -329,11 +329,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     SEGContinueUserActivityPayload *payload = [[SEGContinueUserActivityPayload alloc] init];
     payload.activity = activity;
     [self run:SEGEventTypeContinueUserActivity payload:payload];
-    
+
     if (!self.configuration.trackDeepLinks) {
         return;
     }
-    
+
     if ([activity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
         NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:activity.userInfo.count + 2];
         [properties addEntriesFromDictionary:activity.userInfo];
@@ -349,11 +349,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     payload.url = url;
     payload.options = options;
     [self run:SEGEventTypeOpenURL payload:payload];
-    
+
     if (!self.configuration.trackDeepLinks) {
         return;
     }
-    
+
     NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:options.count + 2];
     [properties addEntriesFromDictionary:options];
     properties[@"url"] = url.absoluteString;

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -130,23 +130,22 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
     if (!previousBuildV2) {
         [self track:@"Application Installed" properties:@{
-            @"version" : currentVersion,
-            @"build" : currentBuild
+            @"version" : currentVersion ?: [NSNull null],
+            @"build" : currentBuild ?: [NSNull null],
         }];
-    } else if (currentBuild != previousBuildV2) {
     } else if (![currentBuild isEqualToString:previousBuildV2]) {
         [self track:@"Application Updated" properties:@{
-            @"previous_version" : previousVersion,
-            @"previous_build" : previousBuildV2,
-            @"version" : currentVersion,
-            @"build" : currentBuild
+            @"previous_version" : previousVersion ?: [NSNull null],
+            @"previous_build" : previousBuildV2 ?: [NSNull null],
+            @"version" : currentVersion ?: [NSNull null],
+            @"build" : currentBuild ?: [NSNull null],
         }];
     }
     
     [self track:@"Application Opened" properties:@{
         @"from_background": @NO,
-        @"version" : currentVersion,
-        @"build" : currentBuild,
+        @"version" : currentVersion ?: [NSNull null],
+        @"build" : currentBuild ?: [NSNull null],
         @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
         @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
     }];
@@ -166,8 +165,8 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
     [self track:@"Application Opened" properties:@{
         @"from_background": @YES,
-        @"version" : currentVersion,
-        @"build" : currentBuild,
+        @"version" : currentVersion ?: [NSNull null],
+        @"build" : currentBuild  ?: [NSNull null],
     }];
 }
 

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -134,6 +134,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
             @"build" : currentBuild
         }];
     } else if (currentBuild != previousBuildV2) {
+    } else if (![currentBuild isEqualToString:previousBuildV2]) {
         [self track:@"Application Updated" properties:@{
             @"previous_version" : previousVersion,
             @"previous_build" : previousBuildV2,

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -142,11 +142,15 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
             @"build" : currentBuild
         }];
     }
-
+    
     [self track:@"Application Opened" properties:@{
+        @"from_background": @NO,
         @"version" : currentVersion,
-        @"build" : currentBuild
+        @"build" : currentBuild,
+        @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
+        @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
     }];
+
 
     [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];
     [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:SEGBuildKeyV2];
@@ -161,8 +165,9 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
     [self track:@"Application Opened" properties:@{
+        @"from_background": @YES,
         @"version" : currentVersion,
-        @"build" : currentBuild
+        @"build" : currentBuild,
     }];
 }
 

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -42,21 +42,21 @@ static SEGAnalytics *__sharedInstance = nil;
 - (instancetype)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration
 {
     NSCParameterAssert(configuration != nil);
-
+    
     if (self = [self init]) {
         self.configuration = configuration;
         self.enabled = YES;
-
+        
         // In swift this would not have been OK... But hey.. It's objc
         // TODO: Figure out if this is really the best way to do things here.
         self.integrationsManager = [[SEGIntegrationsManager alloc] initWithAnalytics:self];
         
         self.runner = [[SEGMiddlewareRunner alloc] initWithMiddlewares:
                        [configuration.middlewares ?: @[] arrayByAddingObject:self.integrationsManager]];
-
+        
         // Attach to application state change hooks
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-
+        
         // Pass through for application state change events
         for (NSString *name in @[ UIApplicationDidEnterBackgroundNotification,
                                   UIApplicationDidFinishLaunchingNotification,
@@ -66,14 +66,14 @@ static SEGAnalytics *__sharedInstance = nil;
                                   UIApplicationDidBecomeActiveNotification ]) {
             [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:nil];
         }
-
+        
         if (configuration.recordScreenViews) {
             [UIViewController seg_swizzleViewDidAppear];
         }
         if (configuration.trackInAppPurchases) {
             _storeKitTracker = [SEGStoreKitTracker trackTransactionsForAnalytics:self];
         }
-
+        
 #if !TARGET_OS_TV
         if (configuration.trackPushNotifications && configuration.launchOptions) {
             NSDictionary *remoteNotification = configuration.launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
@@ -114,43 +114,43 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     if (!self.configuration.trackApplicationLifecycleEvents) {
         return;
     }
-        // Previously SEGBuildKey was stored an integer. This was incorrect because the CFBundleVersion
+    // Previously SEGBuildKey was stored an integer. This was incorrect because the CFBundleVersion
     // can be a string. This migrates SEGBuildKey to be stored as a string.
     NSInteger previousBuildV1 = [[NSUserDefaults standardUserDefaults] integerForKey:SEGBuildKeyV1];
     if (previousBuildV1) {
         [[NSUserDefaults standardUserDefaults] setObject:[@(previousBuildV1) stringValue] forKey:SEGBuildKeyV2];
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:SEGBuildKeyV1];
     }
-
+    
     NSString *previousVersion = [[NSUserDefaults standardUserDefaults] stringForKey:SEGVersionKey];
     NSString *previousBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:SEGBuildKeyV2];
-
+    
     NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
-
+    
     if (!previousBuildV2) {
         [self track:@"Application Installed" properties:@{
-            @"version" : currentVersion,
-            @"build" : currentBuild
-        }];
+                                                          @"version" : currentVersion,
+                                                          @"build" : currentBuild
+                                                          }];
     } else if (currentBuild != previousBuildV2) {
         [self track:@"Application Updated" properties:@{
-            @"previous_version" : previousVersion,
-            @"previous_build" : previousBuildV2,
-            @"version" : currentVersion,
-            @"build" : currentBuild
-        }];
+                                                        @"previous_version" : previousVersion,
+                                                        @"previous_build" : previousBuildV2,
+                                                        @"version" : currentVersion,
+                                                        @"build" : currentBuild
+                                                        }];
     }
     
     [self track:@"Application Opened" properties:@{
-        @"from_background": @NO,
-        @"version" : currentVersion,
-        @"build" : currentBuild,
-        @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
-        @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
-    }];
-
-
+                                                   @"from_background": @NO,
+                                                   @"version" : currentVersion,
+                                                   @"build" : currentBuild,
+                                                   @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
+                                                   @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
+                                                   }];
+    
+    
     [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];
     [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:SEGBuildKeyV2];
     
@@ -164,10 +164,10 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
     [self track:@"Application Opened" properties:@{
-        @"from_background": @YES,
-        @"version" : currentVersion,
-        @"build" : currentBuild,
-    }];
+                                                   @"from_background": @YES,
+                                                   @"version" : currentVersion,
+                                                   @"build" : currentBuild,
+                                                   }];
 }
 
 
@@ -194,11 +194,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 {
     NSCAssert2(userId.length > 0 || traits.count > 0, @"either userId (%@) or traits (%@) must be provided.", userId, traits);
     [self run:SEGEventTypeIdentify payload:
-                                       [[SEGIdentifyPayload alloc] initWithUserId:userId
-                                                                      anonymousId:nil
-                                                                           traits:SEGCoerceDictionary(traits)
-                                                                          context:SEGCoerceDictionary([options objectForKey:@"context"])
-                                                                     integrations:[options objectForKey:@"integrations"]]];
+     [[SEGIdentifyPayload alloc] initWithUserId:userId
+                                    anonymousId:nil
+                                         traits:SEGCoerceDictionary(traits)
+                                        context:SEGCoerceDictionary([options objectForKey:@"context"])
+                                   integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Track
@@ -217,10 +217,10 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 {
     NSCAssert1(event.length > 0, @"event (%@) must not be empty.", event);
     [self run:SEGEventTypeTrack payload:
-                                    [[SEGTrackPayload alloc] initWithEvent:event
-                                                                properties:SEGCoerceDictionary(properties)
-                                                                   context:SEGCoerceDictionary([options objectForKey:@"context"])
-                                                              integrations:[options objectForKey:@"integrations"]]];
+     [[SEGTrackPayload alloc] initWithEvent:event
+                                 properties:SEGCoerceDictionary(properties)
+                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
+                               integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Screen
@@ -238,12 +238,12 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 - (void)screen:(NSString *)screenTitle properties:(NSDictionary *)properties options:(NSDictionary *)options
 {
     NSCAssert1(screenTitle.length > 0, @"screen name (%@) must not be empty.", screenTitle);
-
+    
     [self run:SEGEventTypeScreen payload:
-                                     [[SEGScreenPayload alloc] initWithName:screenTitle
-                                                                 properties:SEGCoerceDictionary(properties)
-                                                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
-                                                               integrations:[options objectForKey:@"integrations"]]];
+     [[SEGScreenPayload alloc] initWithName:screenTitle
+                                 properties:SEGCoerceDictionary(properties)
+                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
+                               integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Group
@@ -261,10 +261,10 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 - (void)group:(NSString *)groupId traits:(NSDictionary *)traits options:(NSDictionary *)options
 {
     [self run:SEGEventTypeGroup payload:
-                                    [[SEGGroupPayload alloc] initWithGroupId:groupId
-                                                                      traits:SEGCoerceDictionary(traits)
-                                                                     context:SEGCoerceDictionary([options objectForKey:@"context"])
-                                                                integrations:[options objectForKey:@"integrations"]]];
+     [[SEGGroupPayload alloc] initWithGroupId:groupId
+                                       traits:SEGCoerceDictionary(traits)
+                                      context:SEGCoerceDictionary([options objectForKey:@"context"])
+                                 integrations:[options objectForKey:@"integrations"]]];
 }
 
 #pragma mark - Alias
@@ -277,9 +277,9 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 - (void)alias:(NSString *)newId options:(NSDictionary *)options
 {
     [self run:SEGEventTypeAlias payload:
-                                    [[SEGAliasPayload alloc] initWithNewId:newId
-                                                                   context:SEGCoerceDictionary([options objectForKey:@"context"])
-                                                              integrations:[options objectForKey:@"integrations"]]];
+     [[SEGAliasPayload alloc] initWithNewId:newId
+                                    context:SEGCoerceDictionary([options objectForKey:@"context"])
+                               integrations:[options objectForKey:@"integrations"]]];
 }
 
 - (void)trackPushNotification:(NSDictionary *)properties fromLaunch:(BOOL)launch
@@ -329,11 +329,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     SEGContinueUserActivityPayload *payload = [[SEGContinueUserActivityPayload alloc] init];
     payload.activity = activity;
     [self run:SEGEventTypeContinueUserActivity payload:payload];
-
+    
     if (!self.configuration.trackDeepLinks) {
         return;
     }
-
+    
     if ([activity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
         NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:activity.userInfo.count + 2];
         [properties addEntriesFromDictionary:activity.userInfo];
@@ -349,11 +349,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     payload.url = url;
     payload.options = options;
     [self run:SEGEventTypeOpenURL payload:payload];
-
+    
     if (!self.configuration.trackDeepLinks) {
         return;
     }
-
+    
     NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:options.count + 2];
     [properties addEntriesFromDictionary:options];
     properties[@"url"] = url.absoluteString;

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -217,7 +217,6 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 - (void)track:(NSString *)event properties:(NSDictionary *)properties options:(NSDictionary *)options
 {
     NSCAssert1(event.length > 0, @"event (%@) must not be empty.", event);
-    NSLog(@"SEGAnalytics - track: %@ properties: %@ options: %@", event, properties, options);
     [self run:SEGEventTypeTrack payload:
                                     [[SEGTrackPayload alloc] initWithEvent:event
                                                                 properties:SEGCoerceDictionary(properties)

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -104,7 +104,6 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     [self run:SEGEventTypeApplicationLifecycle payload:payload];
     
     if ([note.name isEqualToString:UIApplicationDidFinishLaunchingNotification]) {
-        NSLog(@"note.userInfo %@", note.userInfo);
         [self _applicationDidFinishLaunchingWithOptions:note.userInfo];
     } else if ([note.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
         [self _applicationWillEnterForeground];

--- a/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
+++ b/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
@@ -20,7 +20,7 @@ NSString *const SEGMENT_WRITE_KEY = @"zr5x22gUVBDM3hO3uHkbMkVe6Pd6sCna";
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [SEGAnalytics debug:YES];
+    [SEGAnalytics debug:NO];
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:SEGMENT_WRITE_KEY];
     configuration.trackApplicationLifecycleEvents = YES;
     configuration.trackAttributionData = YES;
@@ -28,35 +28,33 @@ NSString *const SEGMENT_WRITE_KEY = @"zr5x22gUVBDM3hO3uHkbMkVe6Pd6sCna";
     [SEGAnalytics setupWithConfiguration:configuration];
     [[SEGAnalytics sharedAnalytics] track:@"Cocoapods Example Launched"];
     [[SEGAnalytics sharedAnalytics] flush];
+    NSLog(@"application:didFinishLaunchingWithOptions: %@", launchOptions);
     return YES;
 }
 
 
 - (void)applicationWillResignActive:(UIApplication *)application {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    NSLog(@"applicationWillResignActive:");
 }
 
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    NSLog(@"applicationDidEnterBackground:");
 }
 
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
-    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    NSLog(@"applicationWillEnterForeground:");
 }
 
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    NSLog(@"applicationDidBecomeActive:");
 }
 
 
 - (void)applicationWillTerminate:(UIApplication *)application {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    NSLog(@"applicationWillTerminate:");
 }
-
 
 @end

--- a/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
+++ b/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
@@ -20,13 +20,13 @@ NSString *const SEGMENT_WRITE_KEY = @"zr5x22gUVBDM3hO3uHkbMkVe6Pd6sCna";
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [SEGAnalytics debug:NO];
+    [SEGAnalytics debug:YES];
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:SEGMENT_WRITE_KEY];
     configuration.trackApplicationLifecycleEvents = YES;
     configuration.trackAttributionData = YES;
     configuration.flushAt = 1;
     [SEGAnalytics setupWithConfiguration:configuration];
-    [[SEGAnalytics sharedAnalytics] track:@"Teresa"];
+    [[SEGAnalytics sharedAnalytics] track:@"Cocoapods Example Launched"];
     [[SEGAnalytics sharedAnalytics] flush];
     NSLog(@"application:didFinishLaunchingWithOptions: %@", launchOptions);
     return YES;

--- a/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
+++ b/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
@@ -26,7 +26,7 @@ NSString *const SEGMENT_WRITE_KEY = @"zr5x22gUVBDM3hO3uHkbMkVe6Pd6sCna";
     configuration.trackAttributionData = YES;
     configuration.flushAt = 1;
     [SEGAnalytics setupWithConfiguration:configuration];
-    [[SEGAnalytics sharedAnalytics] track:@"Cocoapods Example Launched"];
+    [[SEGAnalytics sharedAnalytics] track:@"Teresa"];
     [[SEGAnalytics sharedAnalytics] flush];
     NSLog(@"application:didFinishLaunchingWithOptions: %@", launchOptions);
     return YES;

--- a/Examples/CocoapodsExample/CocoapodsExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/CocoapodsExample/CocoapodsExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/Examples/CocoapodsExample/CocoapodsExample/Info.plist
+++ b/Examples/CocoapodsExample/CocoapodsExample/Info.plist
@@ -25,7 +25,7 @@
 			<string>segment.cocoapodsexample</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>segment-cocapods</string>
+				<string>segment-cocoapods</string>
 			</array>
 		</dict>
 	</array>

--- a/Examples/CocoapodsExample/CocoapodsExample/Info.plist
+++ b/Examples/CocoapodsExample/CocoapodsExample/Info.plist
@@ -16,6 +16,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>segment.cocoapodsexample</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>segment-cocapods</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "8.0"
+    version: "8.2.1"
 
 dependencies:
   pre:


### PR DESCRIPTION
**What does this PR do?**
`Application Opened` is now sent when application moves from background to forground. 
`Application Opened` now includes properties listed in our mobile spec (`from_background`, `referring_application`,`url`) when application available.  For example, when launching app from a URL. 

**What are the relevant tickets?**
https://segment.atlassian.net/browse/EPD-1153

**Questions:**
- Does the docs need an update?
Application Backgrounded: https://github.com/segmentio/site-docs/pull/2158/
Application Opened was not updated in Mobile Spec as it is not consistent with Android functionality

@segmentio/gateway
cc @teresanesteby
