### PR TITLE
Add [session finishTasksAndInvalidate] to SEGHTTPClient.m to prevent memory leak

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -100,6 +100,7 @@
         completionHandler(YES);
     }];
     [task resume];
+    [session finishTasksAndInvalidate];
     return task;
 }
 
@@ -140,6 +141,7 @@
         completionHandler(YES, responseJson);
     }];
     [task resume];
+    [session finishTasksAndInvalidate];
     return task;
 }
 
@@ -200,6 +202,7 @@
         completionHandler(YES, responseJson);
     }];
     [task resume];
+    [session finishTasksAndInvalidate];
     return task;
 }
 


### PR DESCRIPTION
**What does this PR do?**

Add` [session finishTasksAndInvalidate]` to SEGHTTPClient.m to prevent memory leak

**Where should the reviewer start?**

You should release the `NSURLSession` object after using it. Details:

Segment SDK is using `[NSURLSession sessionWithConfiguration:config]` to create NSURLSession object for each task rather than a singleton object.

In Apple's [document](https://developer.apple.com/reference/foundation/urlsession), it says: 

> **Important**
> The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you do not invalidate the session, your app leaks memory until it exits.

There is also an StackOverflow question discussed about this: [http://stackoverflow.com/a/35757989/2627067](http://stackoverflow.com/a/35757989/2627067)

When using Xcode 8's memory debugging tool, you will see a lot of memory leak caused by Segment SDK. 

<img width="1916" alt="2017-03-28 3 45 56" src="https://cloud.githubusercontent.com/assets/12409307/24392176/b53fbffe-13cd-11e7-887f-39a4926779a2.png">

You should add `[session finishTasksAndInvalidate]` after `[task resume]` to allow outstanding tasks to finish before invalidating the object.

**How should this be manually tested?**

Use Xcode 8's memory debugging tool, compare the result with or without `[session finishTasksAndInvalidate]`.

**Any background context you want to provide?**

**What are the relevant tickets?**

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
- Are there any security concerns?
- Do we need to update engineering / success?

@segmentio/gateway