### PR TITLE
Add Builder types

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		3481C14AEC76E5A8DA64DA59 /* Pods_AnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */; };
+		6ECE1D141E79399800E13818 /* TrackPayloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECE1D131E79399800E13818 /* TrackPayloadTest.swift */; };
+		6ECFF4911E7BBE3F001DFB01 /* ScreenPayloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECFF4901E7BBE3F001DFB01 /* ScreenPayloadTest.swift */; };
+		6ECFF4931E7BCC9A001DFB01 /* IdentifyPayloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECFF4921E7BCC9A001DFB01 /* IdentifyPayloadTest.swift */; };
+		6EF21F321E94523F00661460 /* GroupPayloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF21F311E94523F00661460 /* GroupPayloadTest.swift */; };
+		6EF21F341E9456AA00661460 /* AliasPayloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF21F331E9456AA00661460 /* AliasPayloadTest.swift */; };
 		EA88A5981DED7608009FB66A /* SEGSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA88A5971DED7608009FB66A /* SEGSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA8F09741E24C5C600B8B93F /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */; };
 		EADEB8601DECD080005322DA /* Analytics.h in Headers */ = {isa = PBXBuildFile; fileRef = EADEB85E1DECD080005322DA /* Analytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -84,6 +89,11 @@
 
 /* Begin PBXFileReference section */
 		1DF03A6929EEFE7158913224 /* Pods-AnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6ECE1D131E79399800E13818 /* TrackPayloadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TrackPayloadTest.swift; path = Integrations/TrackPayloadTest.swift; sourceTree = "<group>"; };
+		6ECFF4901E7BBE3F001DFB01 /* ScreenPayloadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenPayloadTest.swift; sourceTree = "<group>"; };
+		6ECFF4921E7BCC9A001DFB01 /* IdentifyPayloadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IdentifyPayloadTest.swift; path = Integrations/IdentifyPayloadTest.swift; sourceTree = "<group>"; };
+		6EF21F311E94523F00661460 /* GroupPayloadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupPayloadTest.swift; sourceTree = "<group>"; };
+		6EF21F331E9456AA00661460 /* AliasPayloadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AliasPayloadTest.swift; path = Integrations/AliasPayloadTest.swift; sourceTree = "<group>"; };
 		89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3BF8AE673FE0FD91DF5B503 /* Pods-AnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EA88A5971DED7608009FB66A /* SEGSerializableValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGSerializableValue.h; sourceTree = "<group>"; };
@@ -196,6 +206,18 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		6ECE1D121E79398600E13818 /* Integrations */ = {
+			isa = PBXGroup;
+			children = (
+				6ECE1D131E79399800E13818 /* TrackPayloadTest.swift */,
+				6ECFF4901E7BBE3F001DFB01 /* ScreenPayloadTest.swift */,
+				6ECFF4921E7BCC9A001DFB01 /* IdentifyPayloadTest.swift */,
+				6EF21F311E94523F00661460 /* GroupPayloadTest.swift */,
+				6EF21F331E9456AA00661460 /* AliasPayloadTest.swift */,
+			);
+			name = Integrations;
+			sourceTree = "<group>";
+		};
 		EADEB8511DECD080005322DA = {
 			isa = PBXGroup;
 			children = (
@@ -230,6 +252,7 @@
 		EADEB86B1DECD0EF005322DA /* AnalyticsTests */ = {
 			isa = PBXGroup;
 			children = (
+				6ECE1D121E79398600E13818 /* Integrations */,
 				EADEB8FB1DECD521005322DA /* LSMatcher.h */,
 				EADEB8E11DECD335005322DA /* Utils */,
 				EADEB8E01DECD335005322DA /* HTTPClientTest.swift */,
@@ -577,13 +600,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				EADEB8F51DECD335005322DA /* CryptoTest.swift in Sources */,
+				6EF21F321E94523F00661460 /* GroupPayloadTest.swift in Sources */,
 				EADEB8F21DECD335005322DA /* UserDefaultsStorageTest.swift in Sources */,
+				6ECE1D141E79399800E13818 /* TrackPayloadTest.swift in Sources */,
 				EADEB8F41DECD335005322DA /* ContextTest.swift in Sources */,
+				6EF21F341E9456AA00661460 /* AliasPayloadTest.swift in Sources */,
 				EADEB8EE1DECD335005322DA /* HTTPClientTest.swift in Sources */,
 				EADEB8F31DECD335005322DA /* AnalyticsTests.swift in Sources */,
 				EADEB8F11DECD335005322DA /* FileStorageTest.swift in Sources */,
+				6ECFF4911E7BBE3F001DFB01 /* ScreenPayloadTest.swift in Sources */,
 				EA8F09741E24C5C600B8B93F /* MiddlewareTests.swift in Sources */,
 				EADEB8EF1DECD335005322DA /* NSData+SEGGUNZIPP.m in Sources */,
+				6ECFF4931E7BCC9A001DFB01 /* IdentifyPayloadTest.swift in Sources */,
 				EADEB8F01DECD335005322DA /* TestUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Analytics/Classes/Integrations/SEGAliasPayload.h
+++ b/Analytics/Classes/Integrations/SEGAliasPayload.h
@@ -3,6 +3,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+@interface SEGAliasPayloadBuilder : SEGPayloadBuilder
+
+@property (nonatomic, copy, nullable) NSString *theNewId;
+
+- (instancetype)init;
+
+@end
+
+
 @interface SEGAliasPayload : SEGPayload
 
 @property (nonatomic, readonly) NSString *theNewId;
@@ -10,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithNewId:(NSString *)newId
                       context:(JSON_DICT)context
                  integrations:(JSON_DICT)integrations;
+
+- (instancetype)initWithBuilder:(SEGAliasPayloadBuilder *)builder;
 
 @end
 

--- a/Analytics/Classes/Integrations/SEGAliasPayload.m
+++ b/Analytics/Classes/Integrations/SEGAliasPayload.m
@@ -1,6 +1,18 @@
 #import "SEGAliasPayload.h"
 
 
+@implementation SEGAliasPayloadBuilder
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
+
+@end
+
+
 @implementation SEGAliasPayload
 
 - (instancetype)initWithNewId:(NSString *)newId
@@ -10,6 +22,19 @@
     if (self = [super initWithContext:context integrations:integrations]) {
         _theNewId = [newId copy];
     }
+    return self;
+}
+
+- (instancetype)initWithBuilder:(SEGAliasPayloadBuilder *)builder
+{
+    if (self = [super initWithBuilder:builder]) {
+        NSParameterAssert(builder);
+
+        NSString *theNewId = [builder.theNewId copy];
+        NSCAssert1(theNewId.length > 0, @"newId (%@) must not be null or empty.", theNewId);
+        _theNewId = theNewId;
+    }
+
     return self;
 }
 

--- a/Analytics/Classes/Integrations/SEGGroupPayload.h
+++ b/Analytics/Classes/Integrations/SEGGroupPayload.h
@@ -3,6 +3,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+@interface SEGGroupPayloadBuilder : SEGPayloadBuilder
+
+@property (nonatomic, copy, nullable) NSString *groupId;
+
+@property (nonatomic, copy, nullable) JSON_DICT traits;
+
+- (instancetype)init;
+
+@end
+
+
 @interface SEGGroupPayload : SEGPayload
 
 @property (nonatomic, readonly) NSString *groupId;
@@ -13,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
                          traits:(JSON_DICT _Nullable)traits
                         context:(JSON_DICT)context
                    integrations:(JSON_DICT)integrations;
+
+- (instancetype)initWithBuilder:(SEGGroupPayloadBuilder *)builder;
 
 @end
 

--- a/Analytics/Classes/Integrations/SEGGroupPayload.m
+++ b/Analytics/Classes/Integrations/SEGGroupPayload.m
@@ -1,6 +1,18 @@
 #import "SEGGroupPayload.h"
 
 
+@implementation SEGGroupPayloadBuilder
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
+
+@end
+
+
 @implementation SEGGroupPayload
 
 - (instancetype)initWithGroupId:(NSString *)groupId
@@ -12,6 +24,21 @@
         _groupId = [groupId copy];
         _traits = [traits copy];
     }
+    return self;
+}
+
+- (instancetype)initWithBuilder:(SEGGroupPayloadBuilder *)builder
+{
+    if (self = [super initWithBuilder:builder]) {
+        NSParameterAssert(builder);
+
+        NSString *groupId = [builder.groupId copy];
+        NSCAssert1(groupId.length > 0, @"groupId (%@) must not be null or empty.", groupId);
+        _groupId = groupId;
+
+        _traits = [builder.traits copy];
+    }
+
     return self;
 }
 

--- a/Analytics/Classes/Integrations/SEGIdentifyPayload.h
+++ b/Analytics/Classes/Integrations/SEGIdentifyPayload.h
@@ -3,6 +3,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+@interface SEGIdentifyPayloadBuilder : SEGPayloadBuilder
+
+@property (nonatomic, copy, nullable) NSString *userId;
+
+@property (nonatomic, copy, nullable) NSString *anonymousId;
+
+@property (nonatomic, copy, nullable) JSON_DICT traits;
+
+- (instancetype)init;
+
+@end
+
+
 @interface SEGIdentifyPayload : SEGPayload
 
 @property (nonatomic, readonly, nullable) NSString *userId;
@@ -12,10 +26,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) JSON_DICT traits;
 
 - (instancetype)initWithUserId:(NSString *)userId
-                   anonymousId:(NSString * _Nullable)anonymousId
+                   anonymousId:(NSString *_Nullable)anonymousId
                         traits:(JSON_DICT _Nullable)traits
                        context:(JSON_DICT)context
                   integrations:(JSON_DICT)integrations;
+
+- (instancetype)initWithBuilder:(SEGIdentifyPayloadBuilder *)builder;
 
 @end
 

--- a/Analytics/Classes/Integrations/SEGIdentifyPayload.m
+++ b/Analytics/Classes/Integrations/SEGIdentifyPayload.m
@@ -1,19 +1,50 @@
 #import "SEGIdentifyPayload.h"
 
 
+@implementation SEGIdentifyPayloadBuilder
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
+
+@end
+
+
 @implementation SEGIdentifyPayload
 
 - (instancetype)initWithUserId:(NSString *)userId
                    anonymousId:(NSString *)anonymousId
-                        traits:(NSDictionary *)traits
-                       context:(NSDictionary *)context
-                  integrations:(NSDictionary *)integrations
+                        traits:(JSON_DICT)traits
+                       context:(JSON_DICT)context
+                  integrations:(JSON_DICT)integrations
 {
     if (self = [super initWithContext:context integrations:integrations]) {
         _userId = [userId copy];
         _anonymousId = [anonymousId copy];
         _traits = [traits copy];
     }
+    return self;
+}
+
+- (instancetype)initWithBuilder:(SEGIdentifyPayloadBuilder *)builder
+{
+    if (self = [super initWithBuilder:builder]) {
+        NSParameterAssert(builder);
+
+        NSString *userId = [builder.userId copy];
+        NSString *anonymousId = [builder.anonymousId copy];
+        JSON_DICT traits = [builder.traits copy];
+
+        NSCAssert3(userId.length > 0 || anonymousId.length > 0 || traits.count > 0, @"either userId (%@), anonymousId (%@) or traits (%@) must be provided.", userId, anonymousId, traits);
+
+        _userId = userId;
+        _anonymousId = anonymousId;
+        _traits = traits;
+    }
+
     return self;
 }
 

--- a/Analytics/Classes/Integrations/SEGPayload.h
+++ b/Analytics/Classes/Integrations/SEGPayload.h
@@ -3,12 +3,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+@interface SEGPayloadBuilder : NSObject
+
+@property (nonatomic, copy, nullable) JSON_DICT context;
+
+@property (nonatomic, copy, nullable) JSON_DICT integrations;
+
+- (instancetype)init;
+
+@end
+
+
 @interface SEGPayload : NSObject
 
 @property (nonatomic, readonly) JSON_DICT context;
 @property (nonatomic, readonly) JSON_DICT integrations;
 
 - (instancetype)initWithContext:(JSON_DICT)context integrations:(JSON_DICT)integrations;
+
+- (instancetype)initWithBuilder:(SEGPayloadBuilder *)builder;
 
 @end
 

--- a/Analytics/Classes/Integrations/SEGPayload.m
+++ b/Analytics/Classes/Integrations/SEGPayload.m
@@ -1,6 +1,18 @@
 #import "SEGPayload.h"
 
 
+@implementation SEGPayloadBuilder
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
+
+@end
+
+
 @implementation SEGPayload
 
 - (instancetype)initWithContext:(NSDictionary *)context integrations:(NSDictionary *)integrations
@@ -8,6 +20,15 @@
     if (self = [super init]) {
         _context = [context copy];
         _integrations = [integrations copy];
+    }
+    return self;
+}
+
+- (instancetype)initWithBuilder:(SEGPayloadBuilder *)builder;
+{
+    if (self = [super init]) {
+        _context = [builder.context copy];
+        _integrations = [builder.integrations copy];
     }
     return self;
 }

--- a/Analytics/Classes/Integrations/SEGScreenPayload.h
+++ b/Analytics/Classes/Integrations/SEGScreenPayload.h
@@ -3,18 +3,32 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+@interface SEGScreenPayloadBuilder : SEGPayloadBuilder
+
+@property (nonatomic, copy, nullable) NSString *name;
+
+@property (nonatomic, copy, nullable) JSON_DICT properties;
+
+- (instancetype)init;
+
+@end
+
+
 @interface SEGScreenPayload : SEGPayload
 
 @property (nonatomic, readonly) NSString *name;
 
 @property (nonatomic, readonly, nullable) NSString *category;
 
-@property (nonatomic, readonly, nullable) NSDictionary *properties;
+@property (nonatomic, readonly, nullable) JSON_DICT properties;
 
 - (instancetype)initWithName:(NSString *)name
-                  properties:(NSDictionary * _Nullable)properties
-                     context:(NSDictionary *)context
-                integrations:(NSDictionary *)integrations;
+                  properties:(JSON_DICT _Nullable)properties
+                     context:(JSON_DICT)context
+                integrations:(JSON_DICT)integrations;
+
+- (instancetype)initWithBuilder:(SEGScreenPayloadBuilder *)builder;
 
 @end
 

--- a/Analytics/Classes/Integrations/SEGScreenPayload.m
+++ b/Analytics/Classes/Integrations/SEGScreenPayload.m
@@ -1,17 +1,44 @@
 #import "SEGScreenPayload.h"
 
 
+@implementation SEGScreenPayloadBuilder
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
+
+@end
+
+
 @implementation SEGScreenPayload
 
 - (instancetype)initWithName:(NSString *)name
-                  properties:(NSDictionary *)properties
-                     context:(NSDictionary *)context
-                integrations:(NSDictionary *)integrations
+                  properties:(JSON_DICT)properties
+                     context:(JSON_DICT)context
+                integrations:(JSON_DICT)integrations
 {
     if (self = [super initWithContext:context integrations:integrations]) {
         _name = [name copy];
         _properties = [properties copy];
     }
+    return self;
+}
+
+- (instancetype)initWithBuilder:(SEGScreenPayloadBuilder *)builder
+{
+    if (self = [super initWithBuilder:builder]) {
+        NSParameterAssert(builder);
+
+        NSString *name = [builder.name copy];
+        NSCAssert1(name.length > 0, @"name (%@) must not be null or empty.", name);
+        _name = name;
+
+        _properties = [builder.properties copy];
+    }
+
     return self;
 }
 

--- a/Analytics/Classes/Integrations/SEGTrackPayload.h
+++ b/Analytics/Classes/Integrations/SEGTrackPayload.h
@@ -3,17 +3,32 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+@interface SEGTrackPayloadBuilder : SEGPayloadBuilder
+
+@property (nonatomic, copy) NSString *event;
+
+@property (nonatomic, copy, nullable) JSON_DICT properties;
+
+- (instancetype)init;
+
+@end
+
+
 @interface SEGTrackPayload : SEGPayload
 
 @property (nonatomic, readonly) NSString *event;
 
-@property (nonatomic, readonly, nullable) NSDictionary *properties;
+@property (nonatomic, readonly, nullable) JSON_DICT properties;
 
 - (instancetype)initWithEvent:(NSString *)event
-                   properties:(NSDictionary * _Nullable)properties
-                      context:(NSDictionary *)context
-                 integrations:(NSDictionary *)integrations;
+                   properties:(JSON_DICT _Nullable)properties
+                      context:(JSON_DICT)context
+                 integrations:(JSON_DICT)integrations;
+
+- (instancetype)initWithBuilder:(SEGTrackPayloadBuilder *)builder;
 
 @end
+
 
 NS_ASSUME_NONNULL_END

--- a/Analytics/Classes/Integrations/SEGTrackPayload.m
+++ b/Analytics/Classes/Integrations/SEGTrackPayload.m
@@ -1,18 +1,44 @@
 #import "SEGTrackPayload.h"
 
 
+@implementation SEGTrackPayloadBuilder
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+    }
+    return self;
+}
+
+@end
+
+
 @implementation SEGTrackPayload
 
-
 - (instancetype)initWithEvent:(NSString *)event
-                   properties:(NSDictionary *)properties
-                      context:(NSDictionary *)context
-                 integrations:(NSDictionary *)integrations
+                   properties:(JSON_DICT)properties
+                      context:(JSON_DICT)context
+                 integrations:(JSON_DICT)integrations
 {
     if (self = [super initWithContext:context integrations:integrations]) {
         _event = [event copy];
         _properties = [properties copy];
     }
+    return self;
+}
+
+- (instancetype)initWithBuilder:(SEGTrackPayloadBuilder *)builder
+{
+    if (self = [super initWithBuilder:builder]) {
+        NSParameterAssert(builder);
+
+        NSString *event = [builder.event copy];
+        NSCAssert1(event.length > 0, @"event (%@) must not be null or empty.", event);
+        _event = event;
+
+        _properties = [builder.properties copy];
+    }
+
     return self;
 }
 

--- a/AnalyticsTests/GroupPayloadTest.swift
+++ b/AnalyticsTests/GroupPayloadTest.swift
@@ -1,0 +1,45 @@
+import Quick
+import Nimble
+import Analytics
+
+class GroupPayloadTest: QuickSpec {
+  override func spec() {
+    describe("builder") {
+      it("fails for null name") {
+        expect { SEGGroupPayload(builder: SEGGroupPayloadBuilder()) }.to(raiseException(reason:"groupId ((null)) must not be null or empty."))
+      }
+      
+      it("fails for empty groupId") {
+        let builder = SEGGroupPayloadBuilder()
+        builder.groupId = ""
+        
+        expect { SEGGroupPayload(builder: builder) }.to(raiseException(reason:"groupId () must not be null or empty."))
+      }
+      
+      it("succeeds for valid groupId") {
+        let builder = SEGGroupPayloadBuilder()
+        builder.groupId = "segment"
+        
+        let payload = SEGGroupPayload(builder: builder)
+        expect(payload.groupId) == "segment"
+      }
+      
+      it("succeeds without traits") {
+        let builder = SEGGroupPayloadBuilder()
+        builder.groupId = "segment"
+        
+        let payload = SEGGroupPayload(builder: builder)
+        expect(payload.traits).to(beNil())
+      }
+      
+      it("succeeds for valid traits") {
+        let builder = SEGGroupPayloadBuilder()
+        builder.groupId = "segment"
+        builder.traits = ["name" : "Segment.io, Inc."]
+        
+        let payload = SEGGroupPayload(builder: builder)
+        expect((payload.traits as? NSDictionary)) == ["name" : "Segment.io, Inc."] as NSDictionary
+      }
+    }
+  }
+}

--- a/AnalyticsTests/Integrations/AliasPayloadTest.swift
+++ b/AnalyticsTests/Integrations/AliasPayloadTest.swift
@@ -1,0 +1,28 @@
+import Quick
+import Nimble
+import Analytics
+
+class AliasPayloadTest: QuickSpec {
+  override func spec() {
+    describe("builder") {
+      it("fails for null newId") {
+        expect { SEGAliasPayload(builder: SEGAliasPayloadBuilder()) }.to(raiseException(reason:"newId ((null)) must not be null or empty."))
+      }
+      
+      it("fails for empty newId") {
+        let builder = SEGAliasPayloadBuilder()
+        builder.theNewId = ""
+        
+        expect { SEGAliasPayload(builder: builder) }.to(raiseException(reason:"newId () must not be null or empty."))
+      }
+      
+      it("succeeds for valid new id") {
+        let builder = SEGAliasPayloadBuilder()
+        builder.theNewId = "prateek2"
+        
+        let payload = SEGAliasPayload(builder: builder)
+        expect(payload.theNewId) == "prateek2"
+      }
+    }
+  }
+}

--- a/AnalyticsTests/Integrations/IdentifyPayloadTest.swift
+++ b/AnalyticsTests/Integrations/IdentifyPayloadTest.swift
@@ -1,0 +1,57 @@
+import Quick
+import Nimble
+import Analytics
+
+class IdentifyPayloadTest: QuickSpec {
+  override func spec() {
+    describe("builder") {
+      it("fails for all null fields") {
+        expect { SEGIdentifyPayload(builder: SEGIdentifyPayloadBuilder()) }.to(raiseException(reason:"either userId ((null)), anonymousId ((null)) or traits ((null)) must be provided."))
+      }
+      
+      it("fails for empty userId and anonymousId") {
+        let builder = SEGIdentifyPayloadBuilder()
+        builder.userId = ""
+        builder.anonymousId = ""
+        
+        expect { SEGIdentifyPayload(builder: builder) }.to(raiseException(reason:"either userId (), anonymousId () or traits ((null)) must be provided."))
+      }
+      
+      it("succeeds for valid userId") {
+        let builder = SEGIdentifyPayloadBuilder()
+        builder.userId = "prateek"
+        
+        let payload = SEGIdentifyPayload(builder: builder)
+        expect(payload.userId) == "prateek"
+        expect(payload.anonymousId).to(beNil())
+      }
+      
+      it("succeeds for valid anonymousId") {
+        let builder = SEGIdentifyPayloadBuilder()
+        builder.anonymousId = "foo"
+        
+        let payload = SEGIdentifyPayload(builder: builder)
+        expect(payload.userId).to(beNil())
+        expect(payload.anonymousId) == "foo"
+      }
+      
+      it("succeeds without traits") {
+        let builder = SEGIdentifyPayloadBuilder()
+        builder.anonymousId = "foo"
+        
+        let payload = SEGIdentifyPayload(builder: builder)
+        expect(payload.traits).to(beNil())
+      }
+      
+      it("succeeds for valid traits") {
+        let builder = SEGIdentifyPayloadBuilder()
+        builder.traits = ["age" : 25]
+        
+        let payload = SEGIdentifyPayload(builder: builder)
+        expect(payload.userId).to(beNil())
+        expect(payload.anonymousId).to(beNil())
+        expect((payload.traits as? NSDictionary)) == ["age" : 25] as NSDictionary
+      }
+    }
+  }
+}

--- a/AnalyticsTests/Integrations/TrackPayloadTest.swift
+++ b/AnalyticsTests/Integrations/TrackPayloadTest.swift
@@ -1,0 +1,44 @@
+import Quick
+import Nimble
+import Analytics
+
+class TrackPayloadTest: QuickSpec {
+  override func spec() {
+    describe("builder") {
+      it("fails for null event") {
+        expect { SEGTrackPayload(builder: SEGTrackPayloadBuilder()) }.to(raiseException(reason:"event ((null)) must not be null or empty."))
+      }
+      
+      it("fails for empty event") {
+        let builder = SEGTrackPayloadBuilder()
+        builder.event = ""
+        expect { SEGTrackPayload(builder: builder) }.to(raiseException(reason:"event () must not be null or empty."))
+      }
+      
+      it("succeeds for valid event") {
+        let builder = SEGTrackPayloadBuilder()
+        builder.event = "Completed Order"
+        
+        let payload = SEGTrackPayload(builder: builder)
+        expect(payload.event) == "Completed Order"
+      }
+      
+      it("creates empty properties") {
+        let builder = SEGTrackPayloadBuilder()
+        builder.event = "Completed Order"
+        
+        let payload = SEGTrackPayload(builder: builder)
+        expect(payload.properties).to(beNil())
+      }
+      
+      it("succeeds for valid properties") {
+        let builder = SEGTrackPayloadBuilder()
+        builder.event = "Completed Order"
+        builder.properties = ["revenue" : 10.99]
+        
+        let payload = SEGTrackPayload(builder: builder)
+        expect((payload.properties as! NSDictionary)) == ["revenue" : 10.99] as NSDictionary
+      }
+    }
+  }
+}

--- a/AnalyticsTests/ScreenPayloadTest.swift
+++ b/AnalyticsTests/ScreenPayloadTest.swift
@@ -1,0 +1,44 @@
+import Quick
+import Nimble
+import Analytics
+
+class ScreenPayloadTest: QuickSpec {
+  override func spec() {
+    describe("builder") {
+      it("fails for null name") {
+        expect { SEGScreenPayload(builder: SEGScreenPayloadBuilder()) }.to(raiseException(reason:"name ((null)) must not be null or empty."))
+      }
+      
+      it("fails for empty name") {
+        let builder = SEGScreenPayloadBuilder()
+        builder.name = ""
+        expect { SEGScreenPayload(builder: builder) }.to(raiseException(reason:"name () must not be null or empty."))
+      }
+      
+      it("succeeds for valid name") {
+        let builder = SEGScreenPayloadBuilder()
+        builder.name = "Home"
+        
+        let payload = SEGScreenPayload(builder: builder)
+        expect(payload.name) == "Home"
+      }
+      
+      it("creates empty properties") {
+        let builder = SEGScreenPayloadBuilder()
+        builder.name = "Home"
+      
+        let payload = SEGScreenPayload(builder: builder)
+        expect(payload.properties).to(beNil())
+      }
+      
+      it("succeeds for valid properties") {
+        let builder = SEGScreenPayloadBuilder()
+        builder.name = "Products"
+        builder.properties = ["category" : "Sports"]
+        
+        let payload = SEGScreenPayload(builder: builder)
+        expect((payload.properties as? NSDictionary)) == ["category" : "Sports"] as NSDictionary
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**
Add builder types for payloads. This makes it easier to create payload instances.

**How should this be manually tested?**
Not required. Just verify the automated tests are correct.

Eventually this will be used to simplify how the complicated middlewares are implemented. But not just yet.

@segmentio/gateway
