### PR TITLE
Using string instead of pointer comparision for Application Updated logic

### DIFF
--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -124,7 +124,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
             @"version" : currentVersion,
             @"build" : currentBuild
         }];
-    } else if (currentBuild != previousBuildV2) {
+    } else if (![currentBuild isEqualToString:previousBuildV2]) {
         [self track:@"Application Updated" properties:@{
             @"previous_version" : previousVersion,
             @"previous_build" : previousBuildV2,


### PR DESCRIPTION
Looks like we missed this in the merge to `3.6.0` and introduced a regression, causing problem with `Application Updated` logic. 