### PR TITLE
Add method for clearing user data

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegration.h
+++ b/Analytics/Classes/Integrations/SEGIntegration.h
@@ -45,8 +45,11 @@ NS_ASSUME_NONNULL_BEGIN
 // @see https://segment.com/docs/spec/alias/
 - (void)alias:(SEGAliasPayload *)payload;
 
-// Reset is invoked when the user logs out, and any data saved about the user should be cleared.
+// Reset is invoked when the user logs out, and any data saved about the user and ongoing or cached requests should be cleared.
 - (void)reset;
+
+// Clear user data is invoked when the user logs out, and any data saved about the user should be cleared.
+- (void)clearUserData;
 
 // Flush is invoked when any queued events should be uploaded.
 - (void)flush;

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -263,6 +263,12 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
     [self callIntegrationsWithSelector:_cmd arguments:@[ url, options ] options:nil sync:true];
 }
 
+- (void)clearUserData
+{
+    [self resetAnonymousId];
+    [self callIntegrationsWithSelector:_cmd arguments:nil options:nil sync:false];
+}
+
 - (void)reset
 {
     [self resetAnonymousId];
@@ -561,6 +567,9 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         }
         case SEGEventTypeReset:
             [self reset];
+            break;
+        case SEGEventTypeClearUserData:
+            [self clearUserData];
             break;
         case SEGEventTypeFlush:
             [self flush];

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -510,21 +510,23 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 - (void)reset
 {
     [self dispatchBackgroundAndWait:^{
-        [self.storage removeKey:SEGUserIdKey];
 #if TARGET_OS_TV
-        [self.storage removeKey:SEGTraitsKey];
         [self.storage removeKey:SEGQueueKey];
 #else
-        [self.storage removeKey:kSEGUserIdFilename];
-        [self.storage removeKey:kSEGTraitsFilename];
         [self.storage removeKey:kSEGQueueFilename];
 #endif
 
-        self.userId = nil;
-        self.traits = [NSMutableDictionary dictionary];
+        [self clearUserDataWithoutDispatching];
         self.queue = [NSMutableArray array];
         [self.batchRequest cancel];
         self.batchRequest = nil;
+    }];
+}
+
+- (void)clearUserData
+{
+    [self dispatchBackgroundAndWait:^{
+        [self clearUserDataWithoutDispatching];
     }];
 }
 
@@ -658,6 +660,19 @@ NSString *const SEGTrackedAttributionKey = @"SEGTrackedAttributionKey";
         }];
     }];
 #endif
+}
+
+- (void)clearUserDataWithoutDispatching {
+    [self.storage removeKey:SEGUserIdKey];
+#if TARGET_OS_TV
+    [self.storage removeKey:SEGTraitsKey];
+#else
+    [self.storage removeKey:kSEGUserIdFilename];
+    [self.storage removeKey:kSEGTraitsFilename];
+#endif
+
+    self.userId = nil;
+    self.traits = [NSMutableDictionary dictionary];
 }
 
 @end

--- a/Analytics/Classes/Middlewares/SEGContext.h
+++ b/Analytics/Classes/Middlewares/SEGContext.h
@@ -21,6 +21,7 @@ typedef NS_ENUM(NSInteger, SEGEventType) {
 
     // General utility
     SEGEventTypeReset,
+    SEGEventTypeClearUserData,
     SEGEventTypeFlush,
 
     // Remote Notification

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -168,13 +168,29 @@ NS_ASSUME_NONNULL_BEGIN
  @method
 
  @abstract
+ Reset any user state that is cached on the device and cancel/clear any ongoing/cached requests.
+
+ @discussion
+ This is useful when a user logs out and you want to have clear state of analytics. It will: 
+ - Clear any traits or userId's cached on the device.
+ - Cancel any ongoing/queued requests.
+ - Clear any cached requests.
+
+ If you want to only clear user state see `clearUserData` method.
+ */
+- (void)reset;
+
+/*!
+ @method
+
+ @abstract
  Reset any user state that is cached on the device.
 
  @discussion
  This is useful when a user logs out and you want to clear the identity. It will clear any
  traits or userId's cached on the device.
  */
-- (void)reset;
+- (void)clearUserData;
 
 /*!
  @method

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -360,6 +360,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     [self track:@"Deep Link Opened" properties:[properties copy]];
 }
 
+- (void)clearUserData
+{
+    [self run:SEGEventTypeClearUserData payload:nil];
+}
+
 - (void)reset
 {
     [self run:SEGEventTypeReset payload:nil];

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -68,6 +68,13 @@ class AnalyticsTests: QuickSpec {
       expect(referrer?["url"] as? String) == "http://www.segment.com"
     }
     
+    it("clear user data") {
+      analytics.identify("testUserId1", traits: [ "Test trait key" : "Test trait value"])
+      analytics.clearUserData()
+      expect(analytics.test_integrationsManager()?.test_segmentIntegration()?.test_userId()).toEventually(beNil())
+      expect(analytics.test_integrationsManager()?.test_segmentIntegration()?.test_traits()?.count).toEventually(equal(0))
+    }
+
     it("fires Application Opened for UIApplicationDidFinishLaunching") {
       testMiddleware.swallowEvent = true
       NotificationCenter.default.post(name: .UIApplicationDidFinishLaunching, object: nil, userInfo: [

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -55,6 +55,9 @@ extension SEGSegmentIntegration {
   func test_userId() -> String? {
     return self.value(forKey: "userId") as? String
   }
+  func test_traits() -> [String: AnyObject]? {
+    return self.value(forKey: "traits") as? [String: AnyObject]
+  }
 }
 
 


### PR DESCRIPTION
**What does this PR do?**

Adds a method to clear user data without canceling ongoing requests. See #670.

**Where should the reviewer start?**

In `SEGSegmentIntegration` file where the details of the implementation are.

**How should this be manually tested?**

Set `flushAt` to some high value, maybe 30. Generate tracking events and then call `clearUserData`. All generated tracking events should be send.

**Any background context you want to provide?**

We were calling `reset` after user logged out in our application, but we quickly noticed that calling `reset` also cancels any ongoing request. Since we had `flushAt` set to 5 some of the request generated by the user just before log out action were not send to Segment integration.

**What are the relevant tickets?**

#670 

@segmentio/gateway