### PR TITLE
Remove canceling ongoing requests in reset method.

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -513,18 +513,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         [self.storage removeKey:SEGUserIdKey];
 #if TARGET_OS_TV
         [self.storage removeKey:SEGTraitsKey];
-        [self.storage removeKey:SEGQueueKey];
 #else
         [self.storage removeKey:kSEGUserIdFilename];
         [self.storage removeKey:kSEGTraitsFilename];
-        [self.storage removeKey:kSEGQueueFilename];
 #endif
 
         self.userId = nil;
         self.traits = [NSMutableDictionary dictionary];
-        self.queue = [NSMutableArray array];
-        [self.batchRequest cancel];
-        self.batchRequest = nil;
     }];
 }
 

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -68,6 +68,13 @@ class AnalyticsTests: QuickSpec {
       expect(referrer?["url"] as? String) == "http://www.segment.com"
     }
     
+    it("clears user data") {
+      analytics.identify("testUserId1", traits: [ "Test trait key" : "Test trait value"])
+      analytics.reset()
+      expect(analytics.test_integrationsManager()?.test_segmentIntegration()?.test_userId()).toEventually(beNil())
+      expect(analytics.test_integrationsManager()?.test_segmentIntegration()?.test_traits()?.count).toEventually(equal(0))
+    }
+
     it("fires Application Opened for UIApplicationDidFinishLaunching") {
       testMiddleware.swallowEvent = true
       NotificationCenter.default.post(name: .UIApplicationDidFinishLaunching, object: nil, userInfo: [

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -55,6 +55,9 @@ extension SEGSegmentIntegration {
   func test_userId() -> String? {
     return self.value(forKey: "userId") as? String
   }
+  func test_traits() -> [String: AnyObject]? {
+    return self.value(forKey: "traits") as? [String: AnyObject]
+  }
 }
 
 


### PR DESCRIPTION
**What does this PR do?**

Removes calls to cancel ongoing requests. See #670.

**Where should the reviewer start?**

In `SEGSegmentIntegration.m` file where the calls where removed.

**How should this be manually tested?**

Set `flushAt` to some high value, maybe 30. Generate tracking events and then call `reset`. All generated tracking events should be send.

**Any background context you want to provide?**

We were calling `reset` after user logged out in our application, but we quickly noticed that calling `reset` also cancels any ongoing request. Since we had `flushAt` set to 5 some of the request generated by the user just before log out action were not send to Segment integration.

**What are the relevant tickets?**

#670 

@segmentio/gateway