### PR TITLE
Extract UIApplication to permit linkage with iOS extensions.

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 		EADEB8641DECD080005322DA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -743,6 +744,7 @@
 		EADEB8651DECD080005322DA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -90,7 +90,10 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 
         // Update settings on foreground
-        [nc addObserver:self selector:@selector(onAppForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+        id<SEGApplicationProtocol> application = configuration.application;
+        if (application) {
+            [nc addObserver:self selector:@selector(onAppForeground:) name:UIApplicationWillEnterForegroundNotification object:application];
+        }
     }
     return self;
 }

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -265,10 +265,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     [self endBackgroundTask];
     
     seg_dispatch_specific_sync(_backgroundTaskQueue, ^{
-        self.flushTaskID = [[UIApplication sharedApplication] beginBackgroundTaskWithName:@"Segmentio.Flush"
-                                                                        expirationHandler:^{
-            [self endBackgroundTask];
-        }];
+        id<SEGApplicationProtocol> application = [self.analytics configuration].application;
+        if (application) {
+            self.flushTaskID = [application beginBackgroundTaskWithName:@"Segmentio.Flush"
+                                                      expirationHandler:^{
+                [self endBackgroundTask];
+            }];
+        }
     });
 }
 
@@ -281,7 +284,11 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     // See https://github.com/segmentio/analytics-ios/issues/683
     seg_dispatch_specific_sync(_backgroundTaskQueue, ^{
         if (self.flushTaskID != UIBackgroundTaskInvalid) {
-            [[UIApplication sharedApplication] endBackgroundTask:self.flushTaskID];
+            id<SEGApplicationProtocol> application = [self.analytics configuration].application;
+            if (application) {
+                [application endBackgroundTask:self.flushTaskID];
+            }
+            
             self.flushTaskID = UIBackgroundTaskInvalid;
         }
     });

--- a/Analytics/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Analytics/Classes/Internal/UIViewController+SEGScreen.m
@@ -38,7 +38,7 @@
 
 + (UIViewController *)seg_topViewController
 {
-    UIViewController *root = [UIApplication sharedApplication].delegate.window.rootViewController;
+    UIViewController *root = [[SEGAnalytics sharedAnalytics] configuration].application.delegate.window.rootViewController;
     return [self seg_topViewController:root];
 }
 

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -58,13 +58,16 @@ static SEGAnalytics *__sharedInstance = nil;
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 
         // Pass through for application state change events
-        for (NSString *name in @[ UIApplicationDidEnterBackgroundNotification,
-                                  UIApplicationDidFinishLaunchingNotification,
-                                  UIApplicationWillEnterForegroundNotification,
-                                  UIApplicationWillTerminateNotification,
-                                  UIApplicationWillResignActiveNotification,
-                                  UIApplicationDidBecomeActiveNotification ]) {
-            [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:nil];
+        id<SEGApplicationProtocol> application = configuration.application;
+        if (application) {
+            for (NSString *name in @[ UIApplicationDidEnterBackgroundNotification,
+                                      UIApplicationDidFinishLaunchingNotification,
+                                      UIApplicationWillEnterForegroundNotification,
+                                      UIApplicationWillTerminateNotification,
+                                      UIApplicationWillResignActiveNotification,
+                                      UIApplicationDidBecomeActiveNotification ]) {
+                [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:application];
+            }
         }
 
         if (configuration.recordScreenViews) {

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -7,6 +7,16 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@protocol SEGApplicationProtocol <NSObject>
+@property (nullable, nonatomic, assign) id<UIApplicationDelegate> delegate;
+- (UIBackgroundTaskIdentifier)beginBackgroundTaskWithName:(nullable NSString *)taskName expirationHandler:(void(^ __nullable)(void))handler;
+- (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
+@end
+
+@interface UIApplication ()<SEGApplicationProtocol>
+@end
 
 typedef NSMutableURLRequest * _Nonnull(^SEGRequestFactory)(NSURL * _Nonnull);
 
@@ -111,5 +121,10 @@ typedef NSMutableURLRequest * _Nonnull(^SEGRequestFactory)(NSURL * _Nonnull);
  * Register a factory that can be used to create an integration.
  */
 - (void)use:(id<SEGIntegrationFactory> _Nonnull)factory;
+
+/**
+ * Leave this nil for iOS extensions, otherwise set to UIApplication.sharedApplication.
+ */
+@property (nonatomic, strong, nullable) id<SEGApplicationProtocol> application;
 
 @end

--- a/Analytics/Classes/SEGAnalyticsConfiguration.m
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.m
@@ -41,6 +41,13 @@
         self.shouldUseBluetooth = NO;
         self.flushAt = 20;
         _factories = [NSMutableArray array];
+        Class applicationClass = NSClassFromString(@"UIApplication");
+        if (applicationClass) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+            _application = [applicationClass performSelector:NSSelectorFromString(@"sharedApplication")];
+#pragma clang diagnostic pop
+        }
     }
     return self;
 }

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -22,10 +22,13 @@ class AnalyticsTests: QuickSpec {
     ] as NSDictionary
     var analytics: SEGAnalytics!
     var testMiddleware: TestMiddleware!
+    var testApplication: TestApplication!
     
     beforeEach {
       testMiddleware = TestMiddleware()
       config.middlewares = [testMiddleware]
+      testApplication = TestApplication()
+      config.application = testApplication
       config.trackApplicationLifecycleEvents = true
       
       analytics = SEGAnalytics(configuration: config)
@@ -70,7 +73,7 @@ class AnalyticsTests: QuickSpec {
     
     it("fires Application Opened for UIApplicationDidFinishLaunching") {
       testMiddleware.swallowEvent = true
-      NotificationCenter.default.post(name: .UIApplicationDidFinishLaunching, object: nil, userInfo: [
+      NotificationCenter.default.post(name: .UIApplicationDidFinishLaunching, object: testApplication, userInfo: [
         UIApplicationLaunchOptionsKey.sourceApplication: "testApp",
         UIApplicationLaunchOptionsKey.url: "test://test",
       ])
@@ -83,7 +86,7 @@ class AnalyticsTests: QuickSpec {
     
     it("fires Application Opened during UIApplicationWillEnterForeground") {
       testMiddleware.swallowEvent = true
-      NotificationCenter.default.post(name: .UIApplicationWillEnterForeground, object: nil)
+      NotificationCenter.default.post(name: .UIApplicationWillEnterForeground, object: testApplication)
       let event = testMiddleware.lastContext?.payload as? SEGTrackPayload
       expect(event?.event) == "Application Opened"
       expect(event?.properties?["from_background"] as? Bool) == true

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -91,6 +91,13 @@ class AnalyticsTests: QuickSpec {
       expect(event?.event) == "Application Opened"
       expect(event?.properties?["from_background"] as? Bool) == true
     }
+    
+    it("flushes when UIApplicationDidEnterBackgroundNotification is fired") {
+      analytics.track("test")
+      NotificationCenter.default.post(name: .UIApplicationDidEnterBackground, object: testApplication)
+      expect(testApplication.backgroundTasks.count).toEventually(equal(1))
+      expect(testApplication.backgroundTasks[0].isEnded).toEventually(beFalse())
+    }
   }
 
 }

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -142,11 +142,27 @@ extension LSStubRequestDSL {
 }
 
 class TestApplication: NSObject, SEGApplicationProtocol {
+  class BackgroundTask {
+    let identifier: UInt
+    var isEnded = false
+    
+    init(identifier: UInt) {
+      self.identifier = identifier
+    }
+  }
+  
+  var backgroundTasks = [BackgroundTask]()
+  
+  // MARK: - SEGApplicationProtocol
   var delegate: UIApplicationDelegate? = nil
   func beginBackgroundTask(withName taskName: String?, expirationHandler handler: (() -> Void)? = nil) -> UInt {
-    return 0
+    let backgroundTask = BackgroundTask(identifier: (backgroundTasks.map({ $0.identifier }).max() ?? 0) + 1)
+    backgroundTasks.append(backgroundTask)
+    return backgroundTask.identifier
   }
   
   func endBackgroundTask(_ identifier: UInt) {
+    guard let index = backgroundTasks.index(where: { $0.identifier == identifier }) else { return }
+    backgroundTasks[index].isEnded = true
   }
 }

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -140,3 +140,13 @@ extension LSStubRequestDSL {
         }
     }
 }
+
+class TestApplication: NSObject, SEGApplicationProtocol {
+  var delegate: UIApplicationDelegate? = nil
+  func beginBackgroundTask(withName taskName: String?, expirationHandler handler: (() -> Void)? = nil) -> UInt {
+    return 0
+  }
+  
+  func endBackgroundTask(_ identifier: UInt) {
+  }
+}


### PR DESCRIPTION
**What does this PR do?**
Extract usage of UIApplication into protocol and optional property on config, so the sdk can be used with iOS extensions.

**Where should the reviewer start?**
SEGAnalyticsConfiguration.h

**How should this be manually tested?**
Link with an iOS app, set breakpoints in the appropriate UIApplication notification handlers.

**Any background context you want to provide?**
Also set APPLICATION_EXTENSION_API_ONLY=YES to guard this at build time.

**What are the relevant tickets?**
#213 

**Screenshots or screencasts (if UI/UX change)**
NA

**Questions:**
- Does the docs need an update?
Yes, now by default the optional config.application will be nil unless a non-extension target sets it to UIApplication.shared.

- Are there any security concerns?
No

- Do we need to update engineering / success?
Not sure. Would be nice to build out TestApplication more and add a test to fire UIApplicationDidEnterBackground, and assert that a bg task is added, then removed when the handler is called.

@segmentio/gateway