### PR TITLE
Reuse NSURLSession in SEGHTTPCLient

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -15,6 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SEGHTTPClient : NSObject
 
 @property (nonatomic, strong) SEGRequestFactory requestFactory;
+@property (nonatomic, readonly) NSMutableDictionary<NSString *, NSURLSession *> *sessionsByWriteKey;
+@property (nonatomic, readonly) NSURLSession *genericSession;
 
 + (SEGRequestFactory)defaultRequestFactory;
 + (NSString *)authorizationHeader:(NSString *)writeKey;

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -28,22 +28,42 @@
         } else {
             self.requestFactory = requestFactory;
         }
+        _sessionByWriteKey = [NSMutableDictionary dictionary];
+        NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+        config.HTTPAdditionalHeaders = @{@"Accept-Encoding" : @"gzip"};
+        _genericSession = [NSURLSession sessionWithConfiguration:config];
     }
     return self;
+}
+
+- (NSURLSession *)sessionForWriteKey:(NSString *)writeKey {
+    NSURLSession *session = self.sessionsByWriteKey[writeKey];
+    if (!session) {
+        NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+        config.HTTPAdditionalHeaders = @{
+            @"Accept-Encoding" : @"gzip",
+            @"Content-Encoding" : @"gzip",
+            @"Content-Type" : @"application/json",
+            @"Authorization" : [@"Basic " stringByAppendingString:[[self class] authorizationHeader:writeKey]],
+        };
+        session = [NSURLSession sessionWithConfiguration:config];
+        self.sessionsByWriteKey[writeKey] = session;
+    }
+    return session;
+}
+
+- (void)dealloc {
+    for (NSURLSession *session in self.sessionsByWriteKey.allValues) {
+        [session finishTasksAndInvalidate];
+    }
+    [self.genericSession finishTasksAndInvalidate];
 }
 
 
 - (NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler
 {
     //    batch = SEGCoerceDictionary(batch);
-    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-    config.HTTPAdditionalHeaders = @{
-        @"Accept-Encoding" : @"gzip",
-        @"Content-Encoding" : @"gzip",
-        @"Content-Type" : @"application/json",
-        @"Authorization" : [@"Basic " stringByAppendingString:[[self class] authorizationHeader:writeKey]],
-    };
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+    NSURLSession *session = [self sessionForWriteKey:writeKey];
 
     NSURL *url = [SEGMENT_API_BASE URLByAppendingPathComponent:@"batch"];
     NSMutableURLRequest *request = self.requestFactory(url);
@@ -106,11 +126,7 @@
 
 - (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, JSON_DICT _Nullable settings))completionHandler
 {
-    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-    config.HTTPAdditionalHeaders = @{
-        @"Accept-Encoding" : @"gzip"
-    };
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+    NSURLSession *session = self.genericSession;
 
     NSURL *url = [SEGMENT_CDN_BASE URLByAppendingPathComponent:[NSString stringWithFormat:@"/projects/%@/settings", writeKey]];
     NSMutableURLRequest *request = self.requestFactory(url);
@@ -148,14 +164,7 @@
 - (NSURLSessionDataTask *)attributionWithWriteKey:(NSString *)writeKey forDevice:(JSON_DICT)context completionHandler:(void (^)(BOOL success, JSON_DICT _Nullable properties))completionHandler;
 
 {
-    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-    config.HTTPAdditionalHeaders = @{
-        @"Accept-Encoding" : @"gzip",
-        @"Content-Encoding" : @"gzip",
-        @"Content-Type" : @"application/json",
-        @"Authorization" : [@"Basic " stringByAppendingString:[[self class] authorizationHeader:writeKey]],
-    };
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+    NSURLSession *session = [self sessionForWriteKey:writeKey];
 
     NSURL *url = [MOBILE_SERVICE_BASE URLByAppendingPathComponent:@"/attribution"];
     NSMutableURLRequest *request = self.requestFactory(url);

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -30,7 +30,7 @@
         }
         _sessionsByWriteKey = [NSMutableDictionary dictionary];
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
-        config.HTTPAdditionalHeaders = @{@"Accept-Encoding" : @"gzip"};
+        config.HTTPAdditionalHeaders = @{ @"Accept-Encoding" : @"gzip" };
         _genericSession = [NSURLSession sessionWithConfiguration:config];
     }
     return self;

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -28,7 +28,7 @@
         } else {
             self.requestFactory = requestFactory;
         }
-        _sessionByWriteKey = [NSMutableDictionary dictionary];
+        _sessionsByWriteKey = [NSMutableDictionary dictionary];
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
         config.HTTPAdditionalHeaders = @{@"Accept-Encoding" : @"gzip"};
         _genericSession = [NSURLSession sessionWithConfiguration:config];


### PR DESCRIPTION
Solves issue https://github.com/segmentio/analytics-ios/issues/692#issuecomment-307870908

Reuse the session in client so we do not create it every time. 

When client deallocs, we invalidate the session.