### PR TITLE
SEGIntegration: Importing Context

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegration.h
+++ b/Analytics/Classes/Integrations/SEGIntegration.h
@@ -5,6 +5,7 @@
 #import "SEGAliasPayload.h"
 #import "SEGIdentifyPayload.h"
 #import "SEGGroupPayload.h"
+#import "SEGContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds a missing import, which was causing a compiler warning, when using Segment Analytics via Carthage, in a project completely written in Swift.

<img width="254" alt="screen shot 2017-06-26 at 11 06 57 pm" src="https://user-images.githubusercontent.com/17993217/27567790-7425a540-5ac4-11e7-9e5c-df48e5006f5a.png">

**Where should the reviewer start?**
1. Check out [this sample app](https://github.com/giorgiopaoloni/SegmentSampleApp)
2. Run `carthage bootstrap platform iOS`
3. Build the sample project

As a result, you'll get the compiler warning mentioned above.

**How should this be manually tested?**
Yes!. Map the Sample App's Cartfile to `giorgiopaoloni/analytics-ios` branch `dev` instead, and verify the warning is gone. Note that your Cartfile should look as follows:

```
github "giorgiopaoloni/analytics-ios" "dev"
```

**Any background context you want to provide?**
Not really!

**What are the relevant tickets?**
N/A

**Screenshots or screencasts (if UI/UX change)**
N/A

**Questions:**
- Does the docs need an update?
No need to.

- Are there any security concerns?
No sir!

- Do we need to update engineering / success?
No. Keep up the good work, thanks for helping us out!!

@segmentio/gateway

cc @fredrocious