### PR TITLE
Add workaround for UIApplication type mismatch with Swift mapping.

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -267,8 +267,8 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     seg_dispatch_specific_sync(_backgroundTaskQueue, ^{
         id<SEGApplicationProtocol> application = [self.analytics configuration].application;
         if (application) {
-            self.flushTaskID = [application beginBackgroundTaskWithName:@"Segmentio.Flush"
-                                                      expirationHandler:^{
+            self.flushTaskID = [application seg_beginBackgroundTaskWithName:@"Segmentio.Flush"
+                                                          expirationHandler:^{
                 [self endBackgroundTask];
             }];
         }
@@ -286,7 +286,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         if (self.flushTaskID != UIBackgroundTaskInvalid) {
             id<SEGApplicationProtocol> application = [self.analytics configuration].application;
             if (application) {
-                [application endBackgroundTask:self.flushTaskID];
+                [application seg_endBackgroundTask:self.flushTaskID];
             }
             
             self.flushTaskID = UIBackgroundTaskInvalid;

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -11,11 +11,11 @@
 
 @protocol SEGApplicationProtocol <NSObject>
 @property (nullable, nonatomic, assign) id<UIApplicationDelegate> delegate;
-- (UIBackgroundTaskIdentifier)beginBackgroundTaskWithName:(nullable NSString *)taskName expirationHandler:(void(^ __nullable)(void))handler;
-- (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
+- (UIBackgroundTaskIdentifier)seg_beginBackgroundTaskWithName:(nullable NSString *)taskName expirationHandler:(void(^ __nullable)(void))handler;
+- (void)seg_endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
 @end
 
-@interface UIApplication ()<SEGApplicationProtocol>
+@interface UIApplication (SEGApplicationProtocol)<SEGApplicationProtocol>
 @end
 
 typedef NSMutableURLRequest * _Nonnull(^SEGRequestFactory)(NSURL * _Nonnull);

--- a/Analytics/Classes/SEGAnalyticsConfiguration.m
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.m
@@ -10,6 +10,19 @@
 #import "SEGCrypto.h"
 
 
+@implementation UIApplication (SEGApplicationProtocol)
+
+- (UIBackgroundTaskIdentifier)seg_beginBackgroundTaskWithName:(nullable NSString *)taskName expirationHandler:(void(^ __nullable)(void))handler {
+    return [self beginBackgroundTaskWithName:taskName expirationHandler:handler];
+}
+
+- (void)seg_endBackgroundTask:(UIBackgroundTaskIdentifier)identifier {
+    [self endBackgroundTask:identifier];
+}
+
+@end
+
+
 @interface SEGAnalyticsConfiguration ()
 
 @property (nonatomic, copy, readwrite) NSString *writeKey;

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -105,6 +105,19 @@ class AnalyticsTests: QuickSpec {
       expect(testApplication.backgroundTasks.count).toEventually(equal(1))
       expect(testApplication.backgroundTasks[0].isEnded).toEventually(beFalse())
     }
+    
+    it("protocol conformance should not interfere with UIApplication interface") {
+      // In Xcode8/iOS10, UIApplication.h typedefs UIBackgroundTaskIdentifier as NSUInteger,
+      // whereas Swift has UIBackgroundTaskIdentifier typealiaed to Int.
+      // This is likely due to a custom Swift mapping for UIApplication which got out of sync.
+      // If we extract the exact UIApplication method names in SEGApplicationProtocol,
+      // it will cause a type mismatch between the return value from beginBackgroundTask
+      // and the argument for endBackgroundTask.
+      // This would impact all code in a project that imports the Segment framework.
+      // Note that this doesn't appear to be an issue any longer in Xcode9b3.
+      let task = UIApplication.shared.beginBackgroundTask(expirationHandler: nil)
+      UIApplication.shared.endBackgroundTask(task)
+    }
   }
 
 }

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -158,13 +158,13 @@ class TestApplication: NSObject, SEGApplicationProtocol {
   
   // MARK: - SEGApplicationProtocol
   var delegate: UIApplicationDelegate? = nil
-  func beginBackgroundTask(withName taskName: String?, expirationHandler handler: (() -> Void)? = nil) -> UInt {
+  func seg_beginBackgroundTask(withName taskName: String?, expirationHandler handler: (() -> Void)? = nil) -> UInt {
     let backgroundTask = BackgroundTask(identifier: (backgroundTasks.map({ $0.identifier }).max() ?? 0) + 1)
     backgroundTasks.append(backgroundTask)
     return backgroundTask.identifier
   }
   
-  func endBackgroundTask(_ identifier: UInt) {
+  func seg_endBackgroundTask(_ identifier: UInt) {
     guard let index = backgroundTasks.index(where: { $0.identifier == identifier }) else { return }
     backgroundTasks[index].isEnded = true
   }


### PR DESCRIPTION
**What does this PR do?**
This works around an Apple Swift mapping issue which was found by another developer after integrating the release with this PR: https://github.com/segmentio/analytics-ios/pull/698#issuecomment-315432202

**Where should the reviewer start?**
See the change in AnalyticsTests.swift

**How should this be manually tested?**
No need to manually test, an automated test has been added to AnalyticsTests.swift which would have caught the issue.

**Any background context you want to provide?**
Apple recommended the previous style of protocol extraction and conformance assignment at WWDC17. However, Swift mapping type mismatches will cause issues like this. Luckily it is fairly simple and straightforward to workaround them as needed.

**What are the relevant tickets?**
Not aware that any have been filed yet.

**Screenshots or screencasts (if UI/UX change)**
NA

**Questions:**
- Does the docs need an update? No
- Are there any security concerns? No
- Do we need to update engineering / success? No

@segmentio/gateway