### PR TITLE
Hotfix: queue corruption from NSNull

### DIFF
--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -109,11 +109,6 @@ static id SEGCoerceJSONObject(id obj)
     if ([obj isKindOfClass:[NSDictionary class]]) {
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
         for (NSString *key in obj) {
-            // Hotfix for issue where SEGFileStorage uses plist which does NOT support NSNull
-            // So when `[NSNull null]` gets passed in as track property values the queue serialization fails
-            if ([obj[key] isKindOfClass:[NSNull class]]) {
-                continue;
-            }
             if (![key isKindOfClass:[NSString class]])
                 SEGLog(@"warning: dictionary keys should be strings. got: %@. coercing "
                        @"to: %@",

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -109,6 +109,11 @@ static id SEGCoerceJSONObject(id obj)
     if ([obj isKindOfClass:[NSDictionary class]]) {
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
         for (NSString *key in obj) {
+            // Hotfix for issue where SEGFileStorage uses plist which does NOT support NSNull
+            // So when `[NSNull null]` gets passed in as track property values the queue serialization fails
+            if ([obj[key] isKindOfClass:[NSNull class]]) {
+                continue;
+            }
             if (![key isKindOfClass:[NSString class]])
                 SEGLog(@"warning: dictionary keys should be strings. got: %@. coercing "
                        @"to: %@",

--- a/Analytics/Classes/Internal/SEGStoreKitTracker.m
+++ b/Analytics/Classes/Internal/SEGStoreKitTracker.m
@@ -82,14 +82,14 @@
     [self.analytics track:@"Order Completed" properties:@{
         @"orderId" : transaction.transactionIdentifier,
         @"affiliation" : @"App Store",
-        @"currency" : currency ?: @"",
+        @"currency" : currency ?: [NSNull null],
         @"products" : @[
             @{
                @"sku" : transaction.transactionIdentifier,
                @"quantity" : @(transaction.payment.quantity),
-               @"productId" : product.productIdentifier ?: @"",
-               @"price" : product.price ?: @0,
-               @"name" : product.localizedTitle ?: @"",
+               @"productId" : product.productIdentifier ?: [NSNull null],
+               @"price" : product.price ?: [NSNull null],
+               @"name" : product.localizedTitle ?: [NSNull null],
             }
         ]
     }];

--- a/Analytics/Classes/Internal/SEGStoreKitTracker.m
+++ b/Analytics/Classes/Internal/SEGStoreKitTracker.m
@@ -82,14 +82,14 @@
     [self.analytics track:@"Order Completed" properties:@{
         @"orderId" : transaction.transactionIdentifier,
         @"affiliation" : @"App Store",
-        @"currency" : currency ?: [NSNull null],
+        @"currency" : currency ?: @"",
         @"products" : @[
             @{
                @"sku" : transaction.transactionIdentifier,
                @"quantity" : @(transaction.payment.quantity),
-               @"productId" : product.productIdentifier ?: [NSNull null],
-               @"price" : product.price ?: [NSNull null],
-               @"name" : product.localizedTitle ?: [NSNull null],
+               @"productId" : product.productIdentifier ?: @"",
+               @"price" : product.price ?: @0,
+               @"name" : product.localizedTitle ?: @"",
             }
         ]
     }];

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -133,24 +133,24 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
     if (!previousBuildV2) {
         [self track:@"Application Installed" properties:@{
-            @"version" : currentVersion ?: [NSNull null],
-            @"build" : currentBuild ?: [NSNull null],
+            @"version" : currentVersion ?: @"",
+            @"build" : currentBuild ?: @"",
         }];
     } else if (![currentBuild isEqualToString:previousBuildV2]) {
         [self track:@"Application Updated" properties:@{
-            @"previous_version" : previousVersion ?: [NSNull null],
-            @"previous_build" : previousBuildV2 ?: [NSNull null],
-            @"version" : currentVersion ?: [NSNull null],
-            @"build" : currentBuild ?: [NSNull null],
+            @"previous_version" : previousVersion ?: @"",
+            @"previous_build" : previousBuildV2 ?: @"",
+            @"version" : currentVersion ?: @"",
+            @"build" : currentBuild ?: @"",
         }];
     }
 
     [self track:@"Application Opened" properties:@{
         @"from_background": @NO,
-        @"version" : currentVersion ?: [NSNull null],
-        @"build" : currentBuild ?: [NSNull null],
-        @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
-        @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
+        @"version" : currentVersion ?: @"",
+        @"build" : currentBuild ?: @"",
+        @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: @"",
+        @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: @"",
     }];
 
 
@@ -168,8 +168,8 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
     [self track:@"Application Opened" properties:@{
         @"from_background": @YES,
-        @"version" : currentVersion ?: [NSNull null],
-        @"build" : currentBuild  ?: [NSNull null],
+        @"version" : currentVersion ?: @"",
+        @"build" : currentBuild  ?: @"",
     }];
 }
 

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -133,24 +133,24 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
     if (!previousBuildV2) {
         [self track:@"Application Installed" properties:@{
-            @"version" : currentVersion ?: @"",
-            @"build" : currentBuild ?: @"",
+            @"version" : currentVersion ?: [NSNull null],
+            @"build" : currentBuild ?: [NSNull null],
         }];
     } else if (![currentBuild isEqualToString:previousBuildV2]) {
         [self track:@"Application Updated" properties:@{
-            @"previous_version" : previousVersion ?: @"",
-            @"previous_build" : previousBuildV2 ?: @"",
-            @"version" : currentVersion ?: @"",
-            @"build" : currentBuild ?: @"",
+            @"previous_version" : previousVersion ?: [NSNull null],
+            @"previous_build" : previousBuildV2 ?: [NSNull null],
+            @"version" : currentVersion ?: [NSNull null],
+            @"build" : currentBuild ?: [NSNull null],
         }];
     }
 
     [self track:@"Application Opened" properties:@{
         @"from_background": @NO,
-        @"version" : currentVersion ?: @"",
-        @"build" : currentBuild ?: @"",
-        @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: @"",
-        @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: @"",
+        @"version" : currentVersion ?: [NSNull null],
+        @"build" : currentBuild ?: [NSNull null],
+        @"referring_application": launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: [NSNull null],
+        @"url": launchOptions[UIApplicationLaunchOptionsURLKey] ?: [NSNull null],
     }];
 
 
@@ -168,8 +168,8 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
     [self track:@"Application Opened" properties:@{
         @"from_background": @YES,
-        @"version" : currentVersion ?: @"",
-        @"build" : currentBuild  ?: @"",
+        @"version" : currentVersion ?: [NSNull null],
+        @"build" : currentBuild  ?: [NSNull null],
     }];
 }
 


### PR DESCRIPTION
Property list serialization format (which we currently use for `SEGFileStorage`) does not support `NSNull` (e.g. `CFNull`) values. 
https://stackoverflow.com/questions/6244873/handling-cfnull-objects-in-nspropertylistserialization

As a result, when we send in `NSNull` values the queues will not be able to persist and error will be logged. https://github.com/segmentio/analytics-ios/blob/dev/Analytics/Classes/Internal/SEGFileStorage.m#L154

The longer term fix is to change our serialization format, the immediate hotfix is to stop sending `NSNull`'s in the core SDK and all integrations.

Tested manually confirming the issue has been fixed.

cc @ladanazita @f2prateek @TeresaNesteby @myclamm 