### PR TITLE
Global import needed when using Segment Analytics via Carthage

### DIFF
--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.h
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "SEGSerializableValue.h"
+#import <Analytics/SEGSerializableValue.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
**What does this PR do?**
This PR changes the import of `"SEGSerializableValue.h"` to be a global import `<Analytics/SEGSerializableValue.h>` in `SEGAnalyticsUtils.h` file. Otherwise the file cannot be found when using Segment Analytics via Carthage in a project that uses Localytics integration.
<img width="262" alt="screenshot 2017-08-08 11 54 19" src="https://user-images.githubusercontent.com/6951956/29087479-5c0e9eea-7c33-11e7-9a2c-719d7672e0bc.png">

**Where should the reviewer start?**

1. Check out [this sample app](https://github.com/lbatr3s/SegmentLocalyticsSampleApp)
2. Run carthage bootstrap --platform iOS
3. Build the sample project.

As a result, you'll see a build failure with the error mentioned above.

**How should this be manually tested?**

Map the SegmentLocalyticsSampleApp's Cartfile to `lbatr3s/analytics-ios` branch `dev` instead, and verify the build is successfull. Note that your Cartfile should look as follows:

`github "lbatr3s/analytics-ios" "dev"`

**Any background context you want to provide?**
No.

**What are the relevant tickets?**
N/A

**Screenshots or screencasts (if UI/UX change)**
N/A

**Questions:**
- Does the docs need an update?
No.
- Are there any security concerns?
No.
- Do we need to update engineering / success?
No.

@segmentio/gateway
