### PR TITLE
Disable code coverage to fix app submission with Xcode 9

### DIFF
--- a/Analytics.xcodeproj/xcshareddata/xcschemes/Analytics.xcscheme
+++ b/Analytics.xcodeproj/xcshareddata/xcschemes/Analytics.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
**What does this PR do?**
With this change, apps submitted to `TestFlight` using `Xcode 9.0` will fail with the following error:
> Invalid Bundle - Disallowed LLVM instrumentation. Do not submit apps with LLVM profiling instrumentation or coverage collection enabled. Turn off LLVM profiling or code coverage, rebuild your app and resubmit the app.

**How should this be manually tested?**
Nothing to test, as this only affects running tests.

**Any background context you want to provide?**
See https://github.com/Carthage/Carthage/issues/2056.

**Questions:**
- Does the docs need an update? No
- Are there any security concerns? No
- Do we need to update engineering / success? I don't know?

@segmentio/gateway