### PR TITLE
Format NSDate objects to RFC 3339 compliant strings.

### DIFF
--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -19,7 +19,8 @@ NSString *iso8601FormattedString(NSDate *date)
     dispatch_once(&onceToken, ^{
         dateFormatter = [[NSDateFormatter alloc] init];
         dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-        dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+        dateFormatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS'Z'";
+        dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     });
     return [dateFormatter stringFromDate:date];
 }


### PR DESCRIPTION
**What does this PR do?**

Fixes and issue where dates were not being formatted correctly before being sent to Segment. The correct way to handle RFC 3339 with NSDateFormatter is detailed here: https://developer.apple.com/library/content/qa/qa1480/_index.html. The one small change is to include milliseconds as they were there previously. This will still be RFC 3339 compliant as can be seen here: https://tools.ietf.org/html/rfc3339#section-5.8. 

**Where should the reviewer start?**

N/A

**How should this be manually tested?**

Sends some date data through the SDK and verify it is being formatted correctly.

**Any background context you want to provide?**

After talking to Segment support I learned our date traits were not being sent to Redshift because they were not RFC 3339 compliant. The link to the support ticket is here: 
 https://segment.zendesk.com/hc/requests/87566

**What are the relevant tickets?**

N/A

**Screenshots or screencasts (if UI/UX change)**

N/A

**Questions:**
- Does the docs need an update? No
- Are there any security concerns? No
- Do we need to update engineering / success? No

@segmentio/gateway
