### PR TITLE
Respect schema defaults.

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -424,6 +424,8 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         } else {
             return NO;
         }
+    } else if (plan[@"track"][@"__default"]) {
+        return [plan[@"track"][@"__default"][@"enabled"] boolValue];
     }
 
     return YES;

--- a/AnalyticsTests/IntegrationsManagerTest.swift
+++ b/AnalyticsTests/IntegrationsManagerTest.swift
@@ -8,8 +8,13 @@ class IntegrationsManagerTest: QuickSpec {
     describe("IntegrationsManager") {
       context("is track event enabled for integration in plan") {
         
-        it("returns true when plan is empty") {
+        it("returns true when there is no plan") {
           let enabled = SEGIntegrationsManager.isTrackEvent("hello world", enabledForIntegration: "Amplitude", inPlan:[:])
+          expect(enabled).to(beTrue())
+        }
+        
+        it("returns true when plan is empty") {
+          let enabled = SEGIntegrationsManager.isTrackEvent("hello world", enabledForIntegration: "Mixpanel", inPlan:["track":[:]])
           expect(enabled).to(beTrue())
         }
         
@@ -36,6 +41,16 @@ class IntegrationsManagerTest: QuickSpec {
         it("returns false when plan disables event for integration") {
           let enabled = SEGIntegrationsManager.isTrackEvent("hello world", enabledForIntegration: "Mixpanel", inPlan:["track":["hello world":["enabled":true, "integrations":["Mixpanel":false]]]])
           expect(enabled).to(beFalse())
+        }
+        
+        it("returns false when plan disables new events by default") {
+          let enabled = SEGIntegrationsManager.isTrackEvent("hello world", enabledForIntegration: "Mixpanel", inPlan:["track":["__default":["enabled":false]]])
+          expect(enabled).to(beFalse())
+        }
+        
+        it("returns uses event plan rather over defaults") {
+          let enabled = SEGIntegrationsManager.isTrackEvent("hello world", enabledForIntegration: "Mixpanel", inPlan:["track":["__default":["enabled":false],"hello world":["enabled":true]]])
+          expect(enabled).to(beTrue())
         }
       }
     }


### PR DESCRIPTION
If an event is not present in the tracking plan, we'll now lookup the schema defaults for the project.

If the event is disabled in the schema default, it will only be sent to the Segment integration (i.e. api.segment.io).

If the event is enabled in the schema default, it will be sent to all integrations.

Ref: https://paper.dropbox.com/doc/Schema-Client-Side-Defaults-DufdS8Ej43mnFXvvMqm1b
