### PR TITLE
Fix validation when there’s no name of view controller

### DIFF
--- a/Analytics/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Analytics/Classes/Internal/UIViewController+SEGScreen.m
@@ -66,7 +66,7 @@
     }
 
     NSString *name = [top title];
-    if (!name) {
+    if (!name || name.length == 0) {
         name = [[[top class] description] stringByReplacingOccurrencesOfString:@"ViewController" withString:@""];
         // Class name could be just "ViewController".
         if (name.length == 0) {


### PR DESCRIPTION
fixing issue number [729](https://github.com/segmentio/analytics-ios/issues/729)

app was crashing when `recordScreenViews ` is true and try to report a screen with no name (like UIAlertController) and the validation was failing because [top title] returns an empty string instead of nil, so, validation was only with nil, i add the empty validation to get the name of the class
