### PR TITLE
Makefile: archive should run carthage target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint:
 carthage:
 	carthage build --no-skip-current
 
-archive:
+archive: carthage
 	carthage archive Analytics
 
 clean:


### PR DESCRIPTION
This is reqiured to properly build the Carthage binaries that are up to date with the source.

See #12.
