### PR TITLE
sharedAnalytics returns null before setup

### DIFF
--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @see -setupWithConfiguration:
  */
-+ (instancetype)sharedAnalytics;
++ (instancetype _Nullable)sharedAnalytics;
 
 /*!
  @method


### PR DESCRIPTION
**What does this PR do?**

changes `+ (instancetype)sharedAnalytics;` to `+ (instancetype _Nullable)sharedAnalytics;`

**Where should the reviewer start?**

at `+ (instancetype)sharedAnalytics;`

**How should this be manually tested?**

It shouldn't change any functionality so whatever sanity tests are normally run should suffice.

**Any background context you want to provide?**

I discovered an instance where an event was attempting to be logged before the client was setup that failed silently. I think this would help prevent that from happening to others.

**What are the relevant tickets?**

https://github.com/segmentio/analytics-ios/issues/743

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?

No

- Are there any security concerns?

No

- Do we need to update engineering / success?

¯\_(ツ)_/¯

@segmentio/gateway
