### PR TITLE
Renames GZIP category to prevent collisions

### DIFF
--- a/Analytics/Classes/Internal/NSData+SEGGZIP.h
+++ b/Analytics/Classes/Internal/NSData+SEGGZIP.h
@@ -36,7 +36,7 @@
 extern void *_Nullable seg_libzOpen(void);
 
 
-@interface NSData (GZIP)
+@interface NSData (SEG_GZIP)
 
 - (nullable NSData *)seg_gzippedData;
 - (BOOL)seg_isGzippedData;

--- a/Analytics/Classes/Internal/NSData+SEGGZIP.m
+++ b/Analytics/Classes/Internal/NSData+SEGGZIP.m
@@ -49,7 +49,7 @@ void *_Nullable seg_libzOpen()
 }
 
 
-@implementation NSData (GZIP)
+@implementation NSData (SEG_GZIP)
 
 - (NSData *)seg_gzippedDataWithCompressionLevel:(float)level
 {


### PR DESCRIPTION
**What does this PR do?**
Renames GZIP category to prevent collisions

**Any background context you want to provide?**
A naming collision happens when the Analytics library is used in a project that also imports the GZIP library as a pod.

**What are the relevant tickets?**
#703

**Questions:**
- Does the docs need an update? **nope**
- Are there any security concerns? **nope**
- Do we need to update engineering / success? **nope**

@segmentio/gateway
