### PR TITLE
Reset SEGUserIdKey only on tvOS

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -517,8 +517,8 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 - (void)reset
 {
     [self dispatchBackgroundAndWait:^{
-        [self.storage removeKey:SEGUserIdKey];
 #if TARGET_OS_TV
+        [self.storage removeKey:SEGUserIdKey];
         [self.storage removeKey:SEGTraitsKey];
 #else
         [self.storage removeKey:kSEGUserIdFilename];


### PR DESCRIPTION
We only set this key on tvOS, so let's remove it only on tvOS as well.

Ref LIB-130, closes #671.