### PR TITLE
Ensure queue is always < 1000 items.

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -417,7 +417,7 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
     if ([key isEqualToString:@"Segment.io"]) {
         return YES;
     }
-    
+
     if (plan[@"track"][event]) {
         if ([plan[@"track"][event][@"enabled"] boolValue]) {
             return [self isIntegration:key enabledInOptions:plan[@"track"][event][@"integrations"]];

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.h
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.h
@@ -8,6 +8,8 @@ NSString *GenerateUUIDString(void);
 // Date Utils
 NSString *iso8601FormattedString(NSDate *date);
 
+void trimQueue(NSMutableArray *array, int size);
+
 // Async Utils
 dispatch_queue_t seg_dispatch_queue_create_specific(const char *label,
                                                     dispatch_queue_attr_t _Nullable attr);

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -25,6 +25,20 @@ NSString *iso8601FormattedString(NSDate *date)
     return [dateFormatter stringFromDate:date];
 }
 
+/** trim the queue so that it contains only upto `max` number of elements. */
+void trimQueue(NSMutableArray *queue, int max)
+{
+    if (queue.count < max) {
+        return;
+    }
+
+    // Previously we didn't cap the queue. Hence there are cases where
+    // the queue may already be larger than 1000 events. Delete as many
+    // events as required to trim the queue size.
+    NSRange range = NSMakeRange(0, queue.count - max);
+    [queue removeObjectsInRange:range];
+}
+
 // Async Utils
 dispatch_queue_t
 seg_dispatch_queue_create_specific(const char *label,

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -461,10 +461,9 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 - (void)queuePayload:(NSDictionary *)payload
 {
     @try {
-        if (self.queue.count > 1000) {
-            // Remove the oldest element.
-            [self.queue removeObjectAtIndex:0];
-        }
+        // We only queue upto 1000 items, so trim the queue to 1000-1=999
+        // before we add a new element.
+        trimQueue(self.queue, 999);
         [self.queue addObject:payload];
         [self persistQueue];
         [self flushQueueByLength];

--- a/AnalyticsTests/AnalyticsUtilTests.swift
+++ b/AnalyticsTests/AnalyticsUtilTests.swift
@@ -13,12 +13,12 @@ import Analytics
 
 class AnalyticsUtilTests: QuickSpec {
   override func spec() {
-    
+
     it("format NSDate objects to RFC 3339 complaint string") {
       let date = Date(timeIntervalSince1970: 0)
       let formattedString = iso8601FormattedString(date)
       expect(formattedString) == "1970-01-01T00:00:00.000Z"
-      
+
       var components = DateComponents()
       components.year = 1992
       components.month = 8
@@ -33,7 +33,34 @@ class AnalyticsUtilTests: QuickSpec {
       let formattedString2 = iso8601FormattedString(date2)
       expect(formattedString2) == "1992-08-06T11:32:04.335Z"
     }
-    
+
+    describe("trimQueue", {
+      it("does nothing when count < max") {
+        let queue = NSMutableArray(array: [])
+        for i in 1...4 {
+          queue.add(i)
+        }
+        trimQueue(queue, 5)
+        expect(queue) == [1, 2, 3, 4]
+      }
+
+      it("trims when count > max") {
+        let queue = NSMutableArray(array: [])
+        for i in 1...10 {
+          queue.add(i)
+        }
+        trimQueue(queue, 5)
+        expect(queue) == [6, 7, 8, 9, 10]
+      }
+
+      it("does not trim when count == max") {
+        let queue = NSMutableArray(array: [])
+        for i in 1...5 {
+          queue.add(i)
+        }
+        trimQueue(queue, 5)
+        expect(queue) == [1, 2, 3, 4, 5]
+      }
+    })
   }
-  
 }


### PR DESCRIPTION
Previously we didn't cap the queue, and when we added the limit, we only removed the oldest element, rather than fully shrink the queue.

Hence there are cases where the queue may already be larger than 1000 events, and removing a single element at a time isn't as helpful. Now we delete as many events as required to trim the queue size.

Ref: LIB-210

