### PR TITLE
Retry HTTP 429 status codes.

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -97,6 +97,7 @@
 
     NSURLSessionUploadTask *task = [session uploadTaskWithRequest:request fromData:gzippedPayload completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response, NSError *_Nullable error) {
         if (error) {
+            // Network error. Retry.
             SEGLog(@"Error uploading request %@.", error);
             completionHandler(YES);
             return;
@@ -104,24 +105,30 @@
 
         NSInteger code = ((NSHTTPURLResponse *)response).statusCode;
         if (code < 300) {
-            // 2xx response codes.
+            // 2xx response codes. Don't retry.
             completionHandler(NO);
             return;
         }
         if (code < 400) {
-            // 3xx response codes.
+            // 3xx response codes. Retry.
             SEGLog(@"Server responded with unexpected HTTP code %d.", code);
             completionHandler(YES);
             return;
         }
+        if (code == 429) {
+          // 429 response codes. Retry.
+          SEGLog(@"Server limited client with response code %d.", code);
+          completionHandler(YES);
+          return;
+        }
         if (code < 500) {
-            // 4xx response codes.
+            // non-429 4xx response codes. Don't retry.
             SEGLog(@"Server rejected payload with HTTP code %d.", code);
             completionHandler(NO);
             return;
         }
 
-        // 5xx response codes.
+        // 5xx response codes. Retry.
         SEGLog(@"Server error with HTTP code %d.", code);
         completionHandler(YES);
     }];


### PR DESCRIPTION
As per the library guidelines (https://paper.dropbox.com/doc/Analytics-library-guidelines-2trBhLKQD4Soz4VatvuGR#:uid=189560039280582553736180&h2=Handling-Network-Errors), we should be retrying requests when the server responds with HTTP 429 status.
