### PR TITLE
use schema webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,7 @@ build-pretty:
 test-pretty:
 	set -o pipefail && xcodebuild test $(XC_ARGS) $(XC_TEST_ARGS) | xcpretty --report junit
 
-xcbuild:
-	xctool $(XC_ARGS)
-
 xctest:
-	xctool test $(XC_ARGS)
+	xctool $(XC_ARGS) run-tests
 
-.PHONY: bootstrap lint carthage archive test xctest build xcbuild clean
+.PHONY: bootstrap lint carthage archive build test xctest clean

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
 test:
   override:
     - sed -i -e 's/RUN_E2E_TESTS = false/RUN_E2E_TESTS = '"$RUN_E2E_TESTS"'/g' AnalyticsTests/EndToEndTests.swift
-    - sed -i -e 's/RUNSCOPE_TOKEN = "{RUNSCOPE_TOKEN}"/RUNSCOPE_TOKEN = "'"$RUNSCOPE_TOKEN"'"/g' AnalyticsTests/EndToEndTests.swift
+    - sed -i -e 's/WEBHOOK_AUTH_USERNAME = "{WEBHOOK_AUTH_USERNAME}"/WEBHOOK_AUTH_USERNAME = "'"$WEBHOOK_AUTH_USERNAME"'"/g' AnalyticsTests/EndToEndTests.swift
     - make build-pretty
     - make test-pretty
     - make lint


### PR DESCRIPTION
Runscope shutdown the traffic inspector (https://blog.runscope.com/posts/phasing-out-traffic-inspector) we were using for our tests.

This migrates to the custom webhook replacement we had built.

Also removes unused xctool commands/updates their usage.


Ref: LIB-458
