### PR TITLE
Custom name/properties for auto screen reporting

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3481C14AEC76E5A8DA64DA59 /* Pods_AnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */; };
+		630FC8EA2107F2A500A759C5 /* SEGScreenReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF0EDFEDC0EE79A0A0EB713 /* SEGScreenReporting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E265C791FB1178C0030E08E /* IntegrationsManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */; };
 		6EEC1C712017EA370089C478 /* EndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEC1C702017EA370089C478 /* EndToEndTests.swift */; };
 		EA88A5981DED7608009FB66A /* SEGSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA88A5971DED7608009FB66A /* SEGSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -89,6 +90,7 @@
 
 /* Begin PBXFileReference section */
 		1DF03A6929EEFE7158913224 /* Pods-AnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5AF0EDFEDC0EE79A0A0EB713 /* SEGScreenReporting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGScreenReporting.h; sourceTree = "<group>"; };
 		6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsManagerTest.swift; sourceTree = "<group>"; };
 		6EEC1C702017EA370089C478 /* EndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndToEndTests.swift; sourceTree = "<group>"; };
 		89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -346,6 +348,7 @@
 				EADEB8A11DECD12B005322DA /* SEGUtils.m */,
 				EADEB8A21DECD12B005322DA /* UIViewController+SEGScreen.h */,
 				EADEB8A31DECD12B005322DA /* UIViewController+SEGScreen.m */,
+				5AF0EDFEDC0EE79A0A0EB713 /* SEGScreenReporting.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -413,6 +416,7 @@
 				EADEB8601DECD080005322DA /* Analytics.h in Headers */,
 				EADEB8C31DECD12B005322DA /* SEGAnalyticsUtils.h in Headers */,
 				EADEB8B91DECD12B005322DA /* SEGIntegrationsManager.h in Headers */,
+				630FC8EA2107F2A500A759C5 /* SEGScreenReporting.h in Headers */,
 				EADEB8AE1DECD12B005322DA /* SEGAES256Crypto.h in Headers */,
 				EADEB8C51DECD12B005322DA /* SEGFileStorage.h in Headers */,
 				EAA5427D1EB42B8C00945DA7 /* SEGReachability.h in Headers */,

--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -541,7 +541,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Alamofire-Synchronous/Alamofire_Synchronous.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
@@ -560,7 +560,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3481C14AEC76E5A8DA64DA59 /* Pods_AnalyticsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */; };
+		5AF0E8AE77F57B356DACCFE7 /* AutoScreenReportingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0E8457CCFC077382BF449 /* AutoScreenReportingTest.swift */; };
 		630FC8EA2107F2A500A759C5 /* SEGScreenReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF0EDFEDC0EE79A0A0EB713 /* SEGScreenReporting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E265C791FB1178C0030E08E /* IntegrationsManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */; };
 		6EEC1C712017EA370089C478 /* EndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEC1C702017EA370089C478 /* EndToEndTests.swift */; };
@@ -90,7 +91,9 @@
 
 /* Begin PBXFileReference section */
 		1DF03A6929EEFE7158913224 /* Pods-AnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5AF0E8457CCFC077382BF449 /* AutoScreenReportingTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoScreenReportingTest.swift; sourceTree = "<group>"; };
 		5AF0EDFEDC0EE79A0A0EB713 /* SEGScreenReporting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGScreenReporting.h; sourceTree = "<group>"; };
+		63E090D722DD49C300DEC7EC /* UIViewController+SegScreenTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+SegScreenTest.h"; sourceTree = "<group>"; };
 		6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsManagerTest.swift; sourceTree = "<group>"; };
 		6EEC1C702017EA370089C478 /* EndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndToEndTests.swift; sourceTree = "<group>"; };
 		89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -268,6 +271,8 @@
 				EADEB8EC1DECD335005322DA /* AnalyticsTests-Bridging-Header.h */,
 				6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */,
 				6EEC1C702017EA370089C478 /* EndToEndTests.swift */,
+				5AF0E8457CCFC077382BF449 /* AutoScreenReportingTest.swift */,
+				63E090D722DD49C300DEC7EC /* UIViewController+SegScreenTest.h */,
 			);
 			indentWidth = 2;
 			path = AnalyticsTests;
@@ -618,6 +623,7 @@
 				EADEB8EF1DECD335005322DA /* NSData+SEGGUNZIPP.m in Sources */,
 				6EEC1C712017EA370089C478 /* EndToEndTests.swift in Sources */,
 				EADEB8F01DECD335005322DA /* TestUtils.swift in Sources */,
+				5AF0E8AE77F57B356DACCFE7 /* AutoScreenReportingTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Analytics.xcodeproj/xcshareddata/xcschemes/AnalyticsTests.xcscheme
+++ b/Analytics.xcodeproj/xcshareddata/xcschemes/AnalyticsTests.xcscheme
@@ -5,6 +5,19 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES"
+            buildForTesting = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EADEB8691DECD0EF005322DA"
+               BuildableName = "AnalyticsTests.xctest"
+               BlueprintName = "AnalyticsTests"
+               ReferencedContainer = "container:Analytics.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/Analytics/Analytics.h
+++ b/Analytics/Analytics.h
@@ -19,3 +19,4 @@ FOUNDATION_EXPORT const unsigned char AnalyticsVersionString[];
 #import "SEGSegmentIntegrationFactory.h"
 #import "SEGContext.h"
 #import "SEGMiddleware.h"
+#import "SEGScreenReporting.h"

--- a/Analytics/Classes/Internal/SEGScreenReporting.h
+++ b/Analytics/Classes/Internal/SEGScreenReporting.h
@@ -1,15 +1,15 @@
 #import <UIKit/UIKit.h>
 #import "SEGSerializableValue.h"
 
-/** Implement this protocol to add properties to automatic screen reporting
+/** Implement this protocol to override automatic screen reporting
  */
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol SEGScreenReporting
-@optional @property (readonly, nullable) NSString * seg_screenName;
-@optional @property (readonly, nullable) SERIALIZABLE_DICT seg_screenProperties;
-@optional @property (readonly, nullable) UIViewController *seg_mainViewController;
+@optional
+-(void) seg_trackScreen:(UIViewController*)screen name:(NSString*)name;
+@property (readonly, nullable) UIViewController *seg_mainViewController;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Analytics/Classes/Internal/SEGScreenReporting.h
+++ b/Analytics/Classes/Internal/SEGScreenReporting.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "SEGSerializableValue.h"
 
 /** Implement this protocol to add properties to automatic screen reporting
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol SEGScreenReporting
 @optional @property (readonly, nullable) NSString * seg_screenName;
 @optional @property (readonly, nullable) SERIALIZABLE_DICT seg_screenProperties;
+@optional @property (readonly, nullable) UIViewController *seg_mainViewController;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Analytics/Classes/Internal/SEGScreenReporting.h
+++ b/Analytics/Classes/Internal/SEGScreenReporting.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+#import "SEGSerializableValue.h"
+
+/** Implement this protocol to add properties to automatic screen reporting
+ */
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SEGScreenReporting
+@optional @property (readonly, nullable) NSString * seg_screenName;
+@optional @property (readonly, nullable) SERIALIZABLE_DICT seg_screenProperties;
+@end
+
+NS_ASSUME_NONNULL_END
+
+

--- a/Analytics/Classes/Internal/UIViewController+SEGScreen.h
+++ b/Analytics/Classes/Internal/UIViewController+SEGScreen.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-
+#import "SEGSerializableValue.h"
 
 @interface UIViewController (SEGScreen)
 
@@ -7,3 +7,4 @@
 + (UIViewController *)seg_topViewController;
 
 @end
+

--- a/Analytics/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Analytics/Classes/Internal/UIViewController+SEGScreen.m
@@ -45,17 +45,49 @@
 
 + (UIViewController *)seg_topViewController:(UIViewController *)rootViewController
 {
-    UIViewController *presentedViewController = rootViewController.presentedViewController;
-    if (presentedViewController != nil) {
-        return [self seg_topViewController:presentedViewController];
-    }
-
-    if ([rootViewController isKindOfClass:[UINavigationController class]]) {
-        UIViewController *lastViewController = [[(UINavigationController *)rootViewController viewControllers] lastObject];
-        return [self seg_topViewController:lastViewController];
+    UIViewController *nextRootViewController = [self seg_nextRootViewController:rootViewController];
+    if (nextRootViewController) {
+        return [self seg_topViewController:nextRootViewController];
     }
 
     return rootViewController;
+}
+
++ (UIViewController *)seg_nextRootViewController:(UIViewController *)rootViewController
+{
+    UIViewController *presentedViewController = rootViewController.presentedViewController;
+    if (presentedViewController != nil) {
+        return presentedViewController;
+    }
+
+    if ([rootViewController isKindOfClass:[UINavigationController class]]) {
+        UIViewController *lastViewController = ((UINavigationController *)rootViewController).viewControllers.lastObject;
+        return lastViewController;
+    }
+
+    if ([rootViewController isKindOfClass:[UITabBarController class]]) {
+        __auto_type *currentTabViewController = ((UITabBarController*)rootViewController).selectedViewController;
+        if (currentTabViewController != nil) {
+            return currentTabViewController;
+        }
+    }
+
+    if (rootViewController.childViewControllers.count > 0) {
+        if ([rootViewController conformsToProtocol:@protocol(SEGScreenReporting)]) {
+            __auto_type screenReporting = (UIViewController<SEGScreenReporting>*)rootViewController;
+            if ([screenReporting respondsToSelector:@selector(seg_mainViewController)]) {
+                return screenReporting.seg_mainViewController;
+            }
+        }
+
+        // fall back on first child UIViewController as a "best guess" assumption
+        __auto_type *firstChildViewController = rootViewController.childViewControllers.firstObject;
+        if (firstChildViewController != nil) {
+            return firstChildViewController;
+        }
+    }
+
+    return nil;
 }
 
 - (void)seg_viewDidAppear:(BOOL)animated

--- a/Analytics/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Analytics/Classes/Internal/UIViewController+SEGScreen.m
@@ -106,7 +106,7 @@
         }
     }
 
-    if ([top conformsToProtocol:@protocol(SEGScreenReporting)] && [top respondsToSelector:@selector(seg_trackScreen)]) {
+    if ([top conformsToProtocol:@protocol(SEGScreenReporting)] && [top respondsToSelector:@selector(seg_trackScreen:name:)]) {
         __auto_type screenReporting = (UIViewController<SEGScreenReporting>*)top;
         [screenReporting seg_trackScreen:top name:name];
         return;

--- a/AnalyticsTests/AnalyticsTests-Bridging-Header.h
+++ b/AnalyticsTests/AnalyticsTests-Bridging-Header.h
@@ -12,7 +12,10 @@
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <Analytics/SEGIntegrationsManager.h>
 #import <Analytics/SEGUtils.h>
+#import <Analytics/SEGScreenReporting.h>
 
 #import "NSData+SEGGUNZIPP.h"
 // Temp hack. We should fix the LSNocilla podspec to make this header publicly available
 #import "LSMatcher.h"
+
+#import "UIViewController+SegScreenTest.h"

--- a/AnalyticsTests/AutoScreenReportingTest.swift
+++ b/AnalyticsTests/AutoScreenReportingTest.swift
@@ -1,0 +1,136 @@
+//
+// Created by David Whetstone on 2018-11-04.
+// Copyright (c) 2018 Segment. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+import SwiftTryCatch
+@testable import Analytics
+
+class AutoScreenReportingTests: QuickSpec {
+
+  override func spec() {
+
+    var window: UIWindow!
+    var rootVC: UIViewController!
+
+    beforeEach {
+      let config = SEGAnalyticsConfiguration(writeKey: "foobar")
+      config.trackApplicationLifecycleEvents = true
+      config.recordScreenViews = true
+
+      window = UIWindow()
+      rootVC = UIViewController()
+      window.addSubview(rootVC.view)
+    }
+
+
+    describe("given a single view controller") {
+
+      it("seg_topViewController returns that view controller") {
+        let actualVC = UIViewController.seg_topViewController(rootVC)
+        expect(actualVC) === rootVC
+      }
+    }
+
+    describe("given a presented view controller") {
+
+      var expectedVC: UIViewController!
+
+      beforeEach {
+        expectedVC = UIViewController()
+        rootVC.present(expectedVC, animated: false)
+      }
+
+      it("seg_topViewController returns the presented view controller") {
+        let actualVC = UIViewController.seg_topViewController(rootVC)
+        expect(actualVC) === expectedVC
+      }
+    }
+
+    describe("given a pushed view controller") {
+
+      var expectedVC: UIViewController!
+
+      beforeEach {
+        expectedVC = UIViewController()
+        let nc = UINavigationController()
+        rootVC.present(nc, animated: false)
+        nc.pushViewController(expectedVC, animated: false)
+      }
+
+      it("seg_topViewController returns the pushed view controller") {
+        let actualVC = UIViewController.seg_topViewController(rootVC)
+        expect(actualVC) === expectedVC
+      }
+    }
+
+    describe("given a child of a UITabBarController") {
+
+      var expectedVC: UIViewController!
+
+      beforeEach {
+        expectedVC = UIViewController()
+        let tabBarController = UITabBarController()
+        rootVC.present(tabBarController, animated: false)
+        tabBarController.viewControllers = [UIViewController(), expectedVC, UIViewController()]
+        tabBarController.selectedIndex = 1
+      }
+
+      it("seg_topViewController returns the currently selected view controller") {
+        let actualVC = UIViewController.seg_topViewController(rootVC)
+        expect(actualVC) === expectedVC
+      }
+    }
+
+    describe("given a child of a custom container view controller conforming to SEGScreenReporting") {
+
+      class CustomContainerViewController: UIViewController, SEGScreenReporting {
+        var selectedIndex: Int = 0
+        var seg_mainViewController: UIViewController? {
+          return childViewControllers[selectedIndex]
+        }
+      }
+
+      var expectedVC: UIViewController!
+
+      beforeEach {
+        expectedVC = UIViewController()
+        let containerVC = CustomContainerViewController()
+        rootVC.present(containerVC, animated: false)
+        [UIViewController(), expectedVC, UIViewController()].forEach { child in
+          containerVC.addChildViewController(child)
+        }
+        containerVC.selectedIndex = 1
+      }
+
+      it("seg_topViewController returns the currently selected view controller") {
+        let actualVC = UIViewController.seg_topViewController(rootVC)
+        expect(actualVC) === expectedVC
+      }
+    }
+
+    describe("given a child of a container view controller NOT conforming to SEGScreenReporting") {
+
+      var expectedVC: UIViewController!
+
+      beforeEach {
+        expectedVC = UIViewController()
+        let containerVC = UIViewController()
+        rootVC.present(containerVC, animated: false)
+        [expectedVC, UIViewController(), UIViewController()].forEach { child in
+          containerVC.addChildViewController(child)
+        }
+      }
+
+      it("seg_topViewController returns the first child view controller") {
+        let actualVC = UIViewController.seg_topViewController(rootVC)
+        expect(actualVC) === expectedVC
+      }
+    }
+  }
+}
+
+

--- a/AnalyticsTests/UIViewController+SegScreenTest.h
+++ b/AnalyticsTests/UIViewController+SegScreenTest.h
@@ -1,0 +1,21 @@
+//
+//  UIViewController+SegScreenTest.h
+//  Analytics
+//
+//  Created by David Whetstone on 7/15/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#ifndef UIViewController_SegScreenTest_h
+#define UIViewController_SegScreenTest_h
+
+
+@interface UIViewController (Testing)
+/// We need to expose this normally private method to tests, as the public facing
+/// `+ (UIViewController *)seg_topViewController` relies on the `application` property
+/// of `SEGAnalyticsConfiguration`, which won't be set in these tests.
++ (UIViewController *)seg_topViewController:(UIViewController *)rootViewController;
+@end
+
+
+#endif /* UIViewController_SegScreenTest_h */

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -82,7 +82,7 @@ class JsonGzippedBody : LSMatcher, LSMatcheable {
     }
     
     func matchesJson(_ json: AnyObject) -> Bool {
-        let actualValue : () -> NSObject! = {
+        let actualValue : () -> NSObject = {
             return json as! NSObject
         }
         let failureMessage = FailureMessage()

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Alamofire (4.6.0)
   - Alamofire-Synchronous (4.0.0):
     - Alamofire (~> 4.0)
-  - Nimble (7.3.1)
+  - Nimble (7.3.4)
   - Nocilla (0.11.0)
   - Quick (1.2.0)
   - SwiftTryCatch (1.0.0)
@@ -35,11 +35,11 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Alamofire: f41a599bd63041760b26d393ec1069d9d7b917f4
   Alamofire-Synchronous: eedf1e6e961c3795a63c74990b3f7d9fbfac7e50
-  Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
+  Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   Nocilla: 7af7a386071150cc8aa5da4da97d060f049dd61c
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   SwiftTryCatch: 2f4ef36cf5396bdb450006b70633dbce5260d3b3
 
 PODFILE CHECKSUM: cf4abb4263c7b514d71c70514284ac657d90865d
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.7.4


### PR DESCRIPTION
**What does this PR do?**

Adds the ability to specify a custom name and custom properties during
automatic screen reporting. 

Also fixes `seg_topViewController()` for `UITabBarController` and custom
container view controllers.

**Where should the reviewer start?**

`UIViewController.seg_viewDidAppear()`

**How should this be manually tested?**

* Create a UIViewController, and conform to the new `SEGScreenReporting`
protocol.  
* Implement `seg_trackScreen` to override the default screen tracking.  Your implementation should call `seg_screen` with custom values for the `screen`, `properties` and/or `options` arguments.
* Implement `seg_mainViewController` to specify which child view
controller of a custom container view controller should be referenced
when determining the top view controller (`seg_topViewController()`)

**Any background context you want to provide?**

None

**What are the relevant tickets?**

Fixes #654

**Screenshots or screencasts (if UI/UX change)**

No UI/UX change

**Questions:**
- Do the docs need an update?

    Yes

- Are there any security concerns?

    Not that I'm aware of 

- Do we need to update engineering / success?

    Not sure what this means

@segmentio/gateway