### PR TITLE
Declare framework dependencies in podspec

### DIFF
--- a/Analytics.podspec
+++ b/Analytics.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
 
-  s.framework = 'Security'
+  s.frameworks = 'CoreTelephony', 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
 
   s.source_files = [
     'Analytics/Classes/**/*',


### PR DESCRIPTION
Users may want to build the pod with Clang modules disabled -fno-modules because they are using ccache which doesn't support -fmodules. When modules are disabled, auto-linking of framework modules is also disabled, so these dependencies need to be expressed explicitly.

**What does this PR do?**

Declares all the frameworks the pod depends on explicitly in the podspec, so that users may disable 'Clang Modules' in order to build the Objective-C code using `ccache` for faster builds. When `CLANG_ENABLE_MODULES` is off, automatic framework linking is also implicitly turned off, so without this declaration the pod no longer links.

**Where should the reviewer start?**

Review that all frameworks listed are used in the pod.

**How should this be manually tested?**

Perform `bundle exec pod install` of this podspec and ensure the pod still builds in the target.

**Questions:**
- Does the docs need an update?

No.

- Are there any security concerns?

No, these are all Apple provided iOS frameworks.

- Do we need to update engineering / success?

No.

@segmentio/gateway
