### PR TITLE
rename install target to dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ XC_TEST_ARGS := -scheme $(TEST_PROJECT) GCC_GENERATE_TEST_COVERAGE_FILES=YES RUN
 bootstrap:
 	.buildscript/bootstrap.sh
 
-install: Podfile Analytics.podspec
+dependencies: Podfile Analytics.podspec
 	pod install
 
 lint:
@@ -42,4 +42,4 @@ test-pretty:
 xctest:
 	xctool $(XC_ARGS) run-tests
 
-.PHONY: bootstrap lint carthage archive build test xctest clean
+.PHONY: bootstrap dependencies lint carthage archive build test xctest clean

--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,10 @@ machine:
 
 dependencies:
   pre:
-#     # - brew install xctool # Homebrew is actually not used on circle at the moment
     - gem install xcpretty
     - gem install cocoapods -v $(var=$(tail -1 Podfile.lock); echo ${var##COCOAPODS:})
-#     - if cd ~/.cocoapods/repos/master; then git pull; else git clone https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master; fi
-#     - pod setup --verbose
   override:
-    - make install
+    - make dependencies
   cache_directories:
     - ./Pods
     - ~/.cocoapods


### PR DESCRIPTION
This is to standardize the makefile as per https://paper.dropbox.com/doc/Analytics-library-guidelines--ALQnS2w9_tQGT30FmYaTEhfEAg-2trBhLKQD4Soz4VatvuGR#:uid=966747111832373010643230&h2=Standardized-Makefile