### PR TITLE
Upgrade to Cocoapods 1.5.3

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -450,7 +450,6 @@
 				EADEB8671DECD0EF005322DA /* Frameworks */,
 				EADEB8681DECD0EF005322DA /* Resources */,
 				B78A9CF1929BFE8D38B50D5C /* [CP] Embed Pods Frameworks */,
-				B179A3824C53C87809396267 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -534,21 +533,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B179A3824C53C87809396267 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B78A9CF1929BFE8D38B50D5C /* [CP] Embed Pods Frameworks */ = {

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ dependencies: Podfile Analytics.podspec
 	pod install
 
 lint:
-	pod lib lint
+	pod lib lint --allow-warnings
 
 carthage:
 	carthage build --no-skip-current

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,6 +15,14 @@ DEPENDENCIES:
   - Quick (~> 1.2.0)
   - SwiftTryCatch (from `https://github.com/segmentio/SwiftTryCatch.git`)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Alamofire-Synchronous
+    - Nimble
+    - Nocilla
+    - Quick
+
 EXTERNAL SOURCES:
   SwiftTryCatch:
     :git: https://github.com/segmentio/SwiftTryCatch.git
@@ -34,4 +42,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 70caa6b2011c61348e6dbbb35d12b64fa7558374
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3


### PR DESCRIPTION
Ref: LIB-546

This should help speed up `pod install` and make it possible to update the lock on latest versions.
See [Cocoapods changelog](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#153-2018-05-25).

@segmentio/gateway
