### PR TITLE
Fix flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       xcode: "9.4.1"
     steps:
       - checkout
+      - run: xcrun simctl list
       - run:
           name: Install build dependencies
           command: |

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -121,19 +121,18 @@ class AnalyticsTests: QuickSpec {
       let integration = analytics.test_integrationsManager()?.test_segmentIntegration()
       expect(integration).notTo(beNil())
       
-      var sent = 0
-
       analytics.flush()
-      integration?.test_dispatchBackground {
-        if let count = integration?.test_queue()?.count {
-          sent = count
-        }
-        else {
-          sent = -1
+      waitUntil(timeout: 60) {done in
+        let queue = DispatchQueue(label: "test")
+        
+        queue.async {
+          while(integration?.test_queue()?.count != max) {
+            sleep(1)
+          }
+
+          done()
         }
       }
-      
-      expect(sent).toEventually(equal(max))
     }
 
     it("protocol conformance should not interfere with UIApplication interface") {

--- a/AnalyticsTests/EndToEndTests.swift
+++ b/AnalyticsTests/EndToEndTests.swift
@@ -65,9 +65,9 @@ class AnalyticsE2ETests: QuickSpec {
 
       analytics.track("E2E Test", properties: ["id": uuid])
 
-      self.waitForExpectations(timeout: 20)
+      self.waitForExpectations(timeout: 3 * 60)
 
-      for _ in 1...5 {
+      for _ in 1...3 * 30 {
         sleep(2)
         if hasMatchingId(messageId: uuid) {
           return


### PR DESCRIPTION
This PR fixes 3 common source of failure for our test :

1. ~Deadlock : sometimes the test runner freeze and needs a total clean to be run. We fix this by removing the need to call the main thread in SegmentIntegration~ Moved to #784
2. Missing iOS simulator : Adding a command to list the simulators seems to magically fix the issue.
3. Flaky maxQueueSize test : I rewrote this one to be more stable

We ran 21+ successful and consecutive test iterations : https://circleci.com/gh/segmentio/workflows/analytics-ios/tree/fix%2Fflaky-test

Ref : LIB-543