### PR TITLE
Fix GCD mutual dependency

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -106,24 +106,16 @@ static BOOL GetAdTrackingEnabled()
             [self trackAttributionData:self.configuration.trackAttributionData];
         }];
 
-        if ([NSThread isMainThread]) {
-            [self setupFlushTimer];
-        } else {
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                [self setupFlushTimer];
-            });
-        }
+        self.flushTimer = [NSTimer timerWithTimeInterval:self.configuration.flushInterval
+                                                  target:self
+                                                selector:@selector(flush)
+                                                userInfo:nil
+                                                 repeats:YES];
+        
+        [NSRunLoop.mainRunLoop addTimer:self.flushTimer
+                                forMode:NSDefaultRunLoopMode];
     }
     return self;
-}
-
-- (void)setupFlushTimer
-{
-    self.flushTimer = [NSTimer scheduledTimerWithTimeInterval:self.configuration.flushInterval
-                                                       target:self
-                                                     selector:@selector(flush)
-                                                     userInfo:nil
-                                                      repeats:YES];
 }
 
 /*


### PR DESCRIPTION
I'm putting this in WIP until we're confident this will not result in regressions.

---

Sometimes the test runner freeze and needs a total clean to be run. We fix this by removing the need to call the main thread in SegmentIntegration by using the proper `NSRunLoop` API.

[Prateek noted](https://github.com/segmentio/analytics-ios/pull/784#discussion_r219051393) :
> We've had some issues around concurrency - particularly as the threads we initialize integrations is not guaranteed.
>
> This causes some integrations and customers to rely on implementation details
that have caused a few issues in the past (#518, #714, #683) so I'd like to be a bit careful rolling this out.