### PR TITLE
Make setting the anonymousId public

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.h
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.h
@@ -26,10 +26,10 @@ extern NSString *_Nonnull SEGAnalyticsIntegrationDidStart;
 @property (nonatomic, readonly) NSMutableDictionary *_Nonnull registeredIntegrations;
 
 - (instancetype _Nonnull)initWithAnalytics:(SEGAnalytics *_Nonnull)analytics;
+- (void)saveAnonymousId:(NSString *)anonymousId;
 
 // @Deprecated - Exposing for backward API compat reasons only
 - (NSString *_Nonnull)getAnonymousId;
-
 @end
 
 

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -144,6 +144,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)alias:(NSString *)newId options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)alias:(NSString *)newId;
 
+/** Sets the anonymous ID of the current user. */
+- (void)setAnonymousId:(NSString *)anonymousId;
+
 // todo: docs
 - (void)receivedRemoteNotification:(NSDictionary *)userInfo;
 - (void)failedToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -390,6 +390,11 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     return [self.integrationsManager getAnonymousId];
 }
 
+- (void)setAnonymousId:(NSString *)anonymousId
+{
+    [self.integrationsManager saveAnonymousId:anonymousId];
+}
+
 - (NSDictionary *)bundledIntegrations
 {
     return [self.integrationsManager.registeredIntegrations copy];


### PR DESCRIPTION
I'm sure there's a reason why saving the anonymousId isn't made public, but I'm not sure what it is, so I'm submitting this PR if, for nothing else, to re-spur the conversation.

**What does this PR do?**
Allows setting of the anonymousId in the integrations manager.

**How should this be manually tested?**
```
segment.getAnonymousId() -> "abc123"
segment.setAnonymousId("test123")
segment.getAnonymousId() -> "test123"
```
Validate in the Segment debugger that the correct anonymous Id comes through.

**What are the relevant tickets?**
https://github.com/segmentio/analytics-ios/issues/753

**Questions:**
- Does the docs need an update? Yes
- Are there any security concerns? I'm not aware of any,
- Do we need to update engineering / success?  *shrug*
