### PR TITLE
Tvos write to file fix and CoreTelephony Fix

### DIFF
--- a/Analytics.podspec
+++ b/Analytics.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
 
-  s.frameworks = 'CoreTelephony', 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
+  s.ios.frameworks = 'CoreTelephony', 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
+  s.tvos.frameworks = 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
 
   s.source_files = [
     'Analytics/Classes/**/*',

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -71,11 +71,7 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.serialQueue = seg_dispatch_queue_create_specific("io.segment.analytics", DISPATCH_QUEUE_SERIAL);
         self.messageQueue = [[NSMutableArray alloc] init];
         self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory];
-#if TARGET_OS_TV
-        self.storage = [[SEGUserDefaultsStorage alloc] initWithDefaults:[NSUserDefaults standardUserDefaults] namespacePrefix:nil crypto:configuration.crypto];
-#else
         self.storage = [[SEGFileStorage alloc] initWithFolder:[SEGFileStorage applicationSupportDirectoryURL] crypto:configuration.crypto];
-#endif
         self.cachedAnonymousId = [self loadOrGenerateAnonymousID:NO];
         NSMutableArray *factories = [[configuration factories] mutableCopy];
         [factories addObject:[[SEGSegmentIntegrationFactory alloc] initWithHTTPClient:self.httpClient storage:self.storage]];

--- a/Analytics/Classes/Internal/SEGFileStorage.m
+++ b/Analytics/Classes/Internal/SEGFileStorage.m
@@ -117,9 +117,15 @@
 
 + (NSURL *)applicationSupportDirectoryURL
 {
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-    NSString *supportPath = [paths firstObject];
-    return [NSURL fileURLWithPath:supportPath];
+    #if TARGET_OS_TV
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        NSString *supportPath = [paths firstObject];
+        return [NSURL fileURLWithPath:supportPath];
+    #else
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+        NSString *supportPath = [paths firstObject];
+        return [NSURL fileURLWithPath:supportPath];
+    #endif
 }
 
 - (NSURL *)urlForKey:(NSString *)key


### PR DESCRIPTION
So we have been having some issues with the user defaults running out of storage space based on other libs for tvos using it on top of segment, you can get around the concept of userdefaults by using the cache directory rather than what you had for ios in particular. 

https://forums.developer.apple.com/thread/20934