### PR TITLE
fix: allow setting anonymousId

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -541,7 +541,15 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
     switch (context.eventType) {
         case SEGEventTypeIdentify: {
             SEGIdentifyPayload *p = (SEGIdentifyPayload *)context.payload;
-            [self identify:p.userId traits:p.traits options:p.options];
+            NSDictionary *options;
+            if (p.anonymousId) {
+                NSMutableDictionary *mutableOptions = [[NSMutableDictionary alloc] initWithDictionary:p.options];
+                mutableOptions[@"anonymousId"] = p.anonymousId;
+                options = [mutableOptions copy];
+            } else {
+                options =  p.options;
+            }
+            [self identify:p.userId traits:p.traits options:options];
             break;
         }
         case SEGEventTypeTrack: {

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -201,7 +201,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSCAssert2(userId.length > 0 || traits.count > 0, @"either userId (%@) or traits (%@) must be provided.", userId, traits);
     [self run:SEGEventTypeIdentify payload:
                                        [[SEGIdentifyPayload alloc] initWithUserId:userId
-                                                                      anonymousId:nil
+                                                                      anonymousId:[options objectForKey:@"anonymousId"]
                                                                            traits:SEGCoerceDictionary(traits)
                                                                           context:SEGCoerceDictionary([options objectForKey:@"context"])
                                                                      integrations:[options objectForKey:@"integrations"]]];

--- a/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
+++ b/Examples/CocoapodsExample/CocoapodsExample/AppDelegate.m
@@ -29,7 +29,11 @@ NSString *const SEGMENT_WRITE_KEY = @"zr5x22gUVBDM3hO3uHkbMkVe6Pd6sCna";
     configuration.trackAttributionData = YES;
     configuration.flushAt = 1;
     [SEGAnalytics setupWithConfiguration:configuration];
+    [[SEGAnalytics sharedAnalytics] identify:@"Prateek" traits:nil options: @{
+                                                                              @"anonymousId":@"test_anonymousId"
+                                                                              }];
     [[SEGAnalytics sharedAnalytics] track:@"Cocoapods Example Launched"];
+
     [[SEGAnalytics sharedAnalytics] flush];
     NSLog(@"application:didFinishLaunchingWithOptions: %@", launchOptions);
     return YES;


### PR DESCRIPTION
Historically, the iOS library has allowed setting a custom anonymous identifier (https://github.com/segmentio/analytics-ios/pull/485).

During adding middlewares, a bug was introduced which started ignoring the anonymousId option.

This fixes the bug and adds a test to validate the fix. This was also tested in the example app end to end and I've verified that events show up with the custom anonymousId.


**What does this PR do?**
Historically, the iOS library has allowed setting a custom anonymous identifier (https://github.com/segmentio/analytics-ios/pull/485).

During adding middlewares, a bug was introduced which started ignoring the anonymousId option.

This fixes the bug and adds a test to validate the fix. This was also tested in the example app end to end and I've verified that events show up with the custom anonymousId.

**How should this be manually tested?**
Test snipet:

```
[[SEGAnalytics sharedAnalytics] identify:@"Prateek" traits:nil options: @{
                                                                           @"anonymousId":@"test_anonymousId"
                                                                         }];
```

Event in debugger: https://cloudup.com/cFyVH4NPR_f

Subsequent events will automatically attach the new anonymous ID https://cloudup.com/cK-i_SCbwsN

Closes #753 

**What are the relevant tickets?**
https://segment.atlassian.net/browse/LIB-266