### PR TITLE
Removed CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF warnings

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -374,7 +374,7 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         }
 
         self.settingsRequest = [self.httpClient settingsForWriteKey:self.configuration.writeKey completionHandler:^(BOOL success, NSDictionary *settings) {
-            seg_dispatch_specific_async(_serialQueue, ^{
+            seg_dispatch_specific_async(self->_serialQueue, ^{
                 if (success) {
                     [self setCachedSettings:settings];
                 } else {


### PR DESCRIPTION
**What does this PR do?**

CocoaPods enabled `CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF` by
default, so enabled it in the project and update the code accordingly.

Blocks within the library implementation direct touch ivars back properties
as part of updating state with doing the work the public access to the
property requires, so use `self->` notation to make it an explicit
capture of `self` instead of an implicit one.

**Any background context you want to provide?**

CocoaPods `CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF`
