### PR TITLE
Add missing context.device.type field required for Kochava integration.

### DIFF
--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -164,6 +164,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     dict[@"device"] = ({
         NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
         dict[@"manufacturer"] = @"Apple";
+        dict[@"type"] = @"ios";
         dict[@"model"] = GetDeviceModel();
         dict[@"id"] = [[device identifierForVendor] UUIDString];
         if (NSClassFromString(SEGAdvertisingClassIdentifier)) {


### PR DESCRIPTION
**What does this PR do?**
Fixes issue 38 in React Native SDK https://github.com/segmentio/analytics-react-native/issues/38

According to Kochava destination docs (https://segment.com/docs/destinations/kochava/#getting-started),  `context.device.type` (has value of ‘ios’ or ‘android’), `context.device.advertising_id` (IDFA on iOS and adID on Android) and `context.device.id` are required in all calls to Kochava. 
`context.device.type` was not being collected, and this fixes data not being shown in Kochava. 
