### PR TITLE
Remove broken .clang-format symlink

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,0 @@
-/Users/prateek/dev/src/github.com/square/spacecommander/.clang-format


### PR DESCRIPTION
**What does this PR do?**
Removes the broken `.clang-format` symlink.

**How should this be manually tested?**
Nope, but you might need to commit a real `.clang-format` file.

**Any background context you want to provide?**
 It was a symlink to a file on one of the dev's local machines, so there's really no reason at all to have it here. If you insist on having a `.clang-format` file in the repo we ought to commit a real one.

**What are the relevant tickets?**
No tickets.

**Questions:**
- Does the docs need an update? -- No
- Are there any security concerns? -- No
- Do we need to update engineering / success? -- No
