### PR TITLE
Fix app updated event

### DIFF
--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -138,13 +138,17 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
             @"version" : currentVersion ?: @"",
             @"build" : currentBuild ?: @"",
         }];
-    } else if (![currentBuild isEqualToString:previousBuildV2]) {
-        [self track:@"Application Updated" properties:@{
-            @"previous_version" : previousVersion ?: @"",
-            @"previous_build" : previousBuildV2 ?: @"",
-            @"version" : currentVersion ?: @"",
-            @"build" : currentBuild ?: @"",
-        }];
+    } else {
+        BOOL versionChanged = ![currentVersion isEqualToString:previousVersion];
+        BOOL buildChanged = ![currentBuild isEqualToString:previousBuildV2];
+        if (versionChanged || (!versionChanged && buildChanged)) {
+            [self track:@"Application Updated" properties:@{
+                @"previous_version" : previousVersion ?: @"",
+                @"previous_build" : previousBuildV2 ?: @"",
+                @"version" : currentVersion ?: @"",
+                @"build" : currentBuild ?: @"",
+            }];
+        }
     }
 
     [self track:@"Application Opened" properties:@{


### PR DESCRIPTION
**What does this PR do?**
Fixes an issue when `Application Updated` event is not being triggered under some circumstances.

**How should this be manually tested?**
If you have a test application, try open the app under these conditions:
* There is no info stored about previous version / build -> `Application Installed` should be triggered
* There is info stored about previous version / build
    * Previous and current versions are the same
        * Previous and current builds the same -> No event should be triggered
        * Previous and current builds are different -> `Application Updated` should be triggered
    * Previous and current versions are different
        * Previous and current builds the same -> `Application Updated` should be triggered
        * Previous and current builds are different -> `Application Updated` should be triggered

**Any background context you want to provide?**
The current implementation id `Application Updated` event only checks if previous and current builds are different. This means that if version has changed but builds didn't, this event will not be triggered.

**Questions:**
- Does the docs need an update? - NO
- Are there any security concerns? - NO
- Do we need to update engineering / success? - NO
