### PR TITLE
Add iOS Backgrounded Event.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.2.1"
     steps:
       - checkout
       - run: xcrun simctl list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: "9.4"
+      xcode: "9.4.1"
     steps:
       - checkout
       - run: xcrun simctl list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: "10.2.1"
+      xcode: "9.4"
     steps:
       - checkout
       - run: xcrun simctl list

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -179,7 +179,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
   if (!self.configuration.trackApplicationLifecycleEvents) {
     return;
   }
-  [self track: @"Application Backgrounded" properties: @{}];
+  [self track: @"Application Backgrounded"];
 }
 
 

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -169,12 +169,8 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     if (!self.configuration.trackApplicationLifecycleEvents) {
         return;
     }
-    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-    NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
     [self track:@"Application Opened" properties:@{
         @"from_background" : @YES,
-        @"version" : currentVersion ?: @"",
-        @"build" : currentBuild ?: @"",
     }];
 }
 
@@ -183,13 +179,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
   if (!self.configuration.trackApplicationLifecycleEvents) {
     return;
   }
-  NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
-  NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
-  [self track: @"Application Backgrounded" properties: @{
-    @"from_background" : @NO,
-    @"version" : currentVersion ?: @"",
-    @"build" : currentBuild ?: @"",
-  }];
+  [self track: @"Application Backgrounded" properties: @{}];
 }
 
 

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -111,6 +111,8 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
         [self _applicationDidFinishLaunchingWithOptions:note.userInfo];
     } else if ([note.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
         [self _applicationWillEnterForeground];
+    } else if ([note.name isEqualToString: UIApplicationDidEnterBackgroundNotification]) {
+      [self _applicationDidEnterBackground];
     }
 }
 
@@ -174,6 +176,20 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
         @"version" : currentVersion ?: @"",
         @"build" : currentBuild ?: @"",
     }];
+}
+
+- (void)_applicationDidEnterBackground
+{
+  if (!self.configuration.trackApplicationLifecycleEvents) {
+    return;
+  }
+  NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+  NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
+  [self track: @"Application Backgrounded" properties: @{
+    @"from_background" : @NO,
+    @"version" : currentVersion ?: @"",
+    @"build" : currentBuild ?: @"",
+  }];
 }
 
 

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -102,6 +102,14 @@ class AnalyticsTests: QuickSpec {
       expect(event?.event) == "Application Opened"
       expect(event?.properties?["from_background"] as? Bool) == true
     }
+    
+    it("fires Application Backgrounded during UIApplicationDidEnterBackground") {
+      testMiddleware.swallowEvent = true
+      NotificationCenter.default.post(name: .UIApplicationDidEnterBackground, object: testApplication)
+      let event = testMiddleware.lastContext?.payload as? SEGTrackPayload
+      expect(event?.event) == "Application Backgrounded"
+      expect(event?.properties?["from_background"] as? Bool) == false
+    }
 
     it("flushes when UIApplicationDidEnterBackgroundNotification is fired") {
       analytics.track("test")

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -108,7 +108,6 @@ class AnalyticsTests: QuickSpec {
       NotificationCenter.default.post(name: .UIApplicationDidEnterBackground, object: testApplication)
       let event = testMiddleware.lastContext?.payload as? SEGTrackPayload
       expect(event?.event) == "Application Backgrounded"
-      expect(event?.properties?["from_background"] as? Bool) == false
     }
 
     it("flushes when UIApplicationDidEnterBackgroundNotification is fired") {

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 target 'AnalyticsTests' do
     platform :ios, '11'
-    
+
     use_frameworks!
-    
+
     pod 'Quick', '~> 1.2.0'
     pod 'Nimble', '~> 7.3.4'
     pod 'Nocilla', '~> 0.11.0'


### PR DESCRIPTION
**What does this PR do?**
Adds the iOS Backgrounded event to the tracking for lifecycle events when enabled

**Where should the reviewer start?**
Link against the library and send the app to background. You should see the backgrounded event.

**How should this be manually tested?**
Link against the library and send the app to background. You should see the backgrounded event.

**Any background context you want to provide?**
This is part of the work from Formidable 

**What are the relevant tickets?**
LIB-1143

**Questions:**
- Does the docs need an update? No (The docs already mention the event)
- Are there any security concerns? No
- Do we need to update engineering / success? No