### PR TITLE
Promoting 3.7.0-beta.4 to release. (#834)

### DIFF
--- a/Analytics.podspec
+++ b/Analytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Analytics"
-  s.version          = "3.7.0-beta.4"
+  s.version          = "3.7.0"
   s.summary          = "The hassle-free way to add analytics to your iOS app."
 
   s.description      = <<-DESC

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -416,7 +416,9 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
 + (NSString *)version
 {
-    return @"3.7.0-beta.4";
+    // this has to match the actual version, NOT what's in info.plist
+    // because Apple only accepts X.X.X as versions in the review process.
+    return @"3.7.0";
 }
 
 #pragma mark - Helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 3.7.0 *(22nd July, 2019)*
+---------------------------------
+
+This release promotes 3.7.0-beta.4 to stable.
+
 Version 3.7.0-beta.4 *(19th June, 2019)*
 -----------------------------------------
  * [Fix](https://github.com/segmentio/analytics-ios/pull/812): Remove invalid `.clang-format` symlink which can cause issues with manual builds.

--- a/Examples/CarthageExample/Cartfile
+++ b/Examples/CarthageExample/Cartfile
@@ -1,3 +1,3 @@
-github "segmentio/analytics-ios" "3.7.0-beta.4"
+github "segmentio/analytics-ios" "3.7.0"
 # Use a local project when debugging
 # git "~/Code/segmentio/analytics-ios/" "master"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Analytics is available through [CocoaPods](http://cocoapods.org) and [Carthage](
 ### CocoaPods
 
 ```ruby
-pod "Analytics", "3.6.10"
+pod "Analytics", "3.7.0"
 ```
 
 ### Carthage


### PR DESCRIPTION
* Prepare for release 3.7.0

* Updated cartfile.

* Updated version in SEGAnalytics.m

* Updated version in readme instructions.