### PR TITLE
`CoreTelephony` library is now only included on iOS targets. 

### DIFF
--- a/Analytics.podspec
+++ b/Analytics.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
 
-  s.frameworks = 'CoreTelephony', 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
+  s.ios.frameworks = 'CoreTelephony'
+  s.frameworks = 'Security', 'StoreKit', 'SystemConfiguration', 'UIKit'
 
   s.source_files = [
     'Analytics/Classes/**/*',


### PR DESCRIPTION
**What does this PR do?**
This makes sure that `CoreTelephony` is only included for iOS targets.

**How should this be manually tested?**
Build a tvOS target with Cocoapods. Include `pod 'Analytics'` as a dependency. Building for actual tvOS hardware (not simulator) will fail. Using this changed podspec will remove the dependency for `CoreTelephony` in tvOS, and will fix the linker error.

**What are the relevant tickets?**
https://github.com/segmentio/analytics-ios/issues/841

**Questions:**
- Does the docs need an update?
  No
- Are there any security concerns? 
  No
- Do we need to update engineering / success?
  No