### PR TITLE
Added support for Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Analytics/Classes/Integrations/SEGIntegration.h
+++ b/Analytics/Classes/Integrations/SEGIntegration.h
@@ -5,7 +5,7 @@
 #import "SEGAliasPayload.h"
 #import "SEGIdentifyPayload.h"
 #import "SEGGroupPayload.h"
-#import "SEGContext.h"
+#import "../Middlewares/SEGContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Analytics/Classes/Integrations/SEGIntegrationFactory.h
+++ b/Analytics/Classes/Integrations/SEGIntegrationFactory.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "SEGIntegration.h"
-#import "SEGAnalytics.h"
+#import "../SEGAnalytics.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.h
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SEGMiddleware.h"
+#import "../Middlewares/SEGMiddleware.h"
 
 /**
  * NSNotification name, that is posted after integrations are loaded.

--- a/Analytics/Classes/Integrations/SEGPayload.h
+++ b/Analytics/Classes/Integrations/SEGPayload.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "SEGSerializableValue.h"
+#import "../SEGSerializableValue.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.h
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <Analytics/SEGSerializableValue.h>
+#import "../SEGSerializableValue.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "SEGAnalytics.h"
+#import "../SEGAnalytics.h"
 
 // TODO: Make this configurable via SEGAnalyticsConfiguration
 // NOTE: `/` at the end kind of screws things up. So don't use it

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.h
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "SEGIntegration.h"
+#import "../Integrations/SEGIntegration.h"
 #import "SEGHTTPClient.h"
 #import "SEGStorage.h"
 

--- a/Analytics/Classes/Internal/SEGSegmentIntegrationFactory.h
+++ b/Analytics/Classes/Internal/SEGSegmentIntegrationFactory.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "SEGIntegrationFactory.h"
+#import "../Integrations/SEGIntegrationFactory.h"
 #import "SEGHTTPClient.h"
 #import "SEGStorage.h"
 

--- a/Analytics/Classes/Internal/SEGStorage.h
+++ b/Analytics/Classes/Internal/SEGStorage.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SEGCrypto.h"
+#import "../Crypto/SEGCrypto.h"
 
 @protocol SEGStorage <NSObject>
 

--- a/Analytics/Classes/Internal/SEGStoreKitTracker.h
+++ b/Analytics/Classes/Internal/SEGStoreKitTracker.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <StoreKit/StoreKit.h>
-#import "SEGAnalytics.h"
+#import "../SEGAnalytics.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Analytics/Classes/Middlewares/SEGContext.h
+++ b/Analytics/Classes/Middlewares/SEGContext.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SEGIntegration.h"
+#import "../Integrations/SEGIntegration.h"
 
 typedef NS_ENUM(NSInteger, SEGEventType) {
     // Should not happen, but default state

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
-#import "SEGIntegrationFactory.h"
-#import "SEGCrypto.h"
+#import "Integrations/SEGIntegrationFactory.h"
+#import "Crypto/SEGCrypto.h"
 #import "SEGAnalyticsConfiguration.h"
 #import "SEGSerializableValue.h"
 

--- a/Analytics/include/Analytics.h
+++ b/Analytics/include/Analytics.h
@@ -1,0 +1,7 @@
+// Header exported by Swift Package Manager
+
+#import "../Classes/SEGAnalytics.h"
+#import "../Classes/Internal/SEGSegmentIntegration.h"
+#import "../Classes/Internal/SEGSegmentIntegrationFactory.h"
+#import "../Classes/Middlewares/SEGContext.h"
+#import "../Classes/Middlewares/SEGMiddleware.h"

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Analytics",
+    products: [
+        .library(
+            name: "Analytics",
+            targets: ["Analytics"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Analytics",
+            path: "Analytics",
+            cSettings: [
+            .headerSearchPath("Classes"),
+            .headerSearchPath("Classes/Crypto"),
+            .headerSearchPath("Classes/Integrations"),
+            .headerSearchPath("Classes/Internal"),
+            .headerSearchPath("Classes/Middlewares"),
+            .headerSearchPath("Vendor"),
+        ]),
+    ]
+)


### PR DESCRIPTION
Just took a second look and reduced the code change a bit for my previous pull request. The conclusion I came to, was that when Swift imports the headers, all the `#import` needs to point to location on disk, as the "Xcode magic" isn't used by SwiftPM. This will require going forward, that the imports are written with the relative path. The `headerSearchPath` in `Package.swift` does allow implementation files to continue just using the header filename in imports.

**What does this PR do?**

Adds support for Swift Package Manager

**Where should the reviewer start?**

By adding the branch as a dependency to a test app in Xcode 11

**How should this be manually tested?**

There should be no functional changes, so just the basic "see if it works" testing after the library has been added to the Xcode project

**Any background context you want to provide?**

We are in the progress of swapping out Carthage with Swift Package Manager and was only missing this library 🙂 

**What are the relevant tickets?**

We have not opened any tickets, but is related to #824 

**Screenshots or screencasts (if UI/UX change)**

No UI changes

**Questions:**
- Does the docs need an update?

Maybe just to indicate that the library can be installed with SwiftPM

- Are there any security concerns?

I don't see there should be any as there are no functional changes to the code.

- Do we need to update engineering / success?