### PR TITLE
Support Xcode 11; Fix warnings; Bump CI to Xcode 10.x from 9.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     macos:
-      xcode: "9.4.1"
+      xcode: "10.3.0"
     steps:
       - checkout
       - run: xcrun simctl list

--- a/Analytics/Classes/SEGAnalyticsConfiguration.m
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.m
@@ -57,6 +57,7 @@
         self.flushAt = 20;
         self.flushInterval = 30;
         self.maxQueueSize = 1000;
+        self.httpSessionDelegate = nil;
         self.payloadFilters = @{
             @"(fb\\d+://authorize#access_token=)([^ ]+)": @"$1((redacted/fb-auth-token))"
         };

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -47,7 +47,7 @@ class AnalyticsTests: QuickSpec {
       expect(analytics.configuration.shouldUseLocationServices) == false
       expect(analytics.configuration.enableAdvertisingTracking) == true
       expect(analytics.configuration.shouldUseBluetooth) == false
-      expect(analytics.configuration.httpSessionDelegate) == nil
+      expect(analytics.configuration.httpSessionDelegate).to(beNil())
       expect(analytics.getAnonymousId()).toNot(beNil())
     }
 

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -82,8 +82,8 @@ class JsonGzippedBody : LSMatcher, LSMatcheable {
     }
     
     func matchesJson(_ json: AnyObject) -> Bool {
-        let actualValue : () -> NSObject! = {
-            return json as! NSObject
+        let actualValue : () -> NSObject? = {
+          return json as? NSObject
         }
         let failureMessage = FailureMessage()
         let location = SourceLocation()

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,7 +16,7 @@ DEPENDENCIES:
   - SwiftTryCatch (from `https://github.com/segmentio/SwiftTryCatch.git`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Alamofire
     - Alamofire-Synchronous
     - Nimble
@@ -40,6 +40,6 @@ SPEC CHECKSUMS:
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   SwiftTryCatch: 2f4ef36cf5396bdb450006b70633dbce5260d3b3
 
-PODFILE CHECKSUM: 96037d813a3e1239ea354ede97146038cd4a31bb
+PODFILE CHECKSUM: 6c11ce6879d40225a5ec2b9b5ac275626edbeeb6
 
-COCOAPODS: 1.7.4
+COCOAPODS: 1.8.3


### PR DESCRIPTION
**What does this PR do?**
- Fixes new warnings in Xcode 11 for analytics-is.
- Fixes issue in init test where httpClientDelegate isn't set correctly.
- Bumps CI to Xcode 10.x from 9.x

**Where should the reviewer start?**
n/a

**How should this be manually tested?**
Pull branch, build and run tests.  Warnings will be observed in dependencies, but not in library code or tests.

**Any background context you want to provide?**
Xcode 11 came out, had yet to verify.

**What are the relevant tickets?**
LIB-1402

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
No

- Are there any security concerns?
No

- Do we need to update engineering / success?
No