### PR TITLE
Fixed LIB-1462

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.h
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.h
@@ -20,6 +20,7 @@ extern NSString *_Nonnull SEGAnalyticsIntegrationDidStart;
 @interface SEGIntegrationsManager : NSObject
 
 // Exposed for testing.
++ (BOOL)isIntegration:(NSString *_Nonnull)key enabledInOptions:(NSDictionary *_Nonnull)options;
 + (BOOL)isTrackEvent:(NSString *_Nonnull)event enabledForIntegration:(NSString *_Nonnull)key inPlan:(NSDictionary *_Nonnull)plan;
 
 // @Deprecated - Exposing for backward API compat reasons only

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -402,7 +402,19 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         return YES;
     }
     if (options[key]) {
-        return [options[key] boolValue];
+        id value = options[key];
+        
+        // it's been observed that customers sometimes override this with
+        // value's that aren't bool types.
+        if ([value isKindOfClass:[NSNumber class]]) {
+            NSNumber *numberValue = (NSNumber *)value;
+            return [numberValue boolValue];
+        } else {
+            NSString *msg = [NSString stringWithFormat: @"Value for `%@` in integration options is supposed to be a boolean and it is not!"
+                             "This is likely due to a user-added value in `integrations` that overwrites a value received from the server", key];
+            SEGLog(msg);
+            NSAssert(NO, msg);
+        }
     } else if (options[@"All"]) {
         return [options[@"All"] boolValue];
     } else if (options[@"all"]) {

--- a/AnalyticsTests/IntegrationsManagerTest.swift
+++ b/AnalyticsTests/IntegrationsManagerTest.swift
@@ -1,6 +1,7 @@
 import Analytics
 import Quick
 import Nimble
+import SwiftTryCatch
 
 class IntegrationsManagerTest: QuickSpec {
   
@@ -8,6 +9,40 @@ class IntegrationsManagerTest: QuickSpec {
     describe("IntegrationsManager") {
       context("is track event enabled for integration in plan") {
         
+        it("asserts when invalid value types are used integration enablement flags") {
+          var exception: NSException? = nil
+          SwiftTryCatch.tryRun({
+            SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["comScore": "blah"])
+          }, catchRun: { e in
+            exception = e
+          }, finallyRun: nil)
+          
+          expect(exception).toNot(beNil())
+        }
+        
+        it("asserts when invalid value types are used integration enablement flags") {
+          var exception: NSException? = nil
+          SwiftTryCatch.tryRun({
+            SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["comScore": ["key": 1]])
+          }, catchRun: { e in
+            exception = e
+          }, finallyRun: nil)
+          
+          expect(exception).toNot(beNil())
+        }
+        
+        it("pulls valid integration data when supplied") {
+          let enabled = SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["comScore": true])
+          expect(enabled).to(beTrue())
+        }
+
+        it("falls back correctly when values aren't explicitly specified") {
+          let enabled = SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["all": true])
+          expect(enabled).to(beTrue())
+          let allEnabled = SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["All": true])
+          expect(allEnabled).to(beTrue())
+        }
+
         it("returns true when there is no plan") {
           let enabled = SEGIntegrationsManager.isTrackEvent("hello world", enabledForIntegration: "Amplitude", inPlan:[:])
           expect(enabled).to(beTrue())


### PR DESCRIPTION
**What does this PR do?**
- Fixes issue where customers overwrite information regarding integration enablement.
- If the server-supplied key doesn't contain the right type (a bool), an assertion is thrown.
- Adds tests to validate this as well as existing fallback functionality.

**What are the relevant tickets?**
LIB-1462

**Questions:**
- Does the docs need an update?
NO
- Are there any security concerns?
NO
- Do we need to update engineering / success?
NO
