### PR TITLE
Reload static context data when the app returns from background.

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6E265C791FB1178C0030E08E /* IntegrationsManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */; };
 		6EEC1C712017EA370089C478 /* EndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEC1C702017EA370089C478 /* EndToEndTests.swift */; };
 		A31958EF2385AC3A00A47EFA /* SerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A31958EE2385AC3A00A47EFA /* SerializationTests.m */; };
+		A352176023AD5825005B07F6 /* SEGMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A352175F23AD5825005B07F6 /* SEGMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EA88A5981DED7608009FB66A /* SEGSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA88A5971DED7608009FB66A /* SEGSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA8F09741E24C5C600B8B93F /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */; };
 		EAA542771EB4035400945DA7 /* TrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA542761EB4035400945DA7 /* TrackingTests.swift */; };
@@ -94,6 +95,7 @@
 		6EEC1C702017EA370089C478 /* EndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndToEndTests.swift; sourceTree = "<group>"; };
 		89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A31958EE2385AC3A00A47EFA /* SerializationTests.m */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = SerializationTests.m; sourceTree = "<group>"; tabWidth = 4; };
+		A352175F23AD5825005B07F6 /* SEGMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEGMacros.h; sourceTree = "<group>"; };
 		D3BF8AE673FE0FD91DF5B503 /* Pods-AnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
 		EA88A5971DED7608009FB66A /* SEGSerializableValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGSerializableValue.h; sourceTree = "<group>"; };
 		EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareTests.swift; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 				EADEB89F1DECD12B005322DA /* SEGUserDefaultsStorage.m */,
 				EADEB8A01DECD12B005322DA /* SEGUtils.h */,
 				EADEB8A11DECD12B005322DA /* SEGUtils.m */,
+				A352175F23AD5825005B07F6 /* SEGMacros.h */,
 				EADEB8A21DECD12B005322DA /* UIViewController+SEGScreen.h */,
 				EADEB8A31DECD12B005322DA /* UIViewController+SEGScreen.m */,
 			);
@@ -410,6 +413,7 @@
 				EADEB8DE1DECD12B005322DA /* SEGAnalyticsConfiguration.h in Headers */,
 				EADEB8D61DECD12B005322DA /* UIViewController+SEGScreen.h in Headers */,
 				EADEB8CF1DECD12B005322DA /* SEGStorage.h in Headers */,
+				A352176023AD5825005B07F6 /* SEGMacros.h in Headers */,
 				EADEB8D21DECD12B005322DA /* SEGUserDefaultsStorage.h in Headers */,
 				EADEB8D01DECD12B005322DA /* SEGStoreKitTracker.h in Headers */,
 				EADEB8D41DECD12B005322DA /* SEGUtils.h in Headers */,

--- a/Analytics/Classes/Internal/SEGMacros.h
+++ b/Analytics/Classes/Internal/SEGMacros.h
@@ -1,0 +1,13 @@
+//
+//  SEGMacros.h
+//  Analytics
+//
+//  Created by Brandon Sneed on 12/20/19.
+//  Copyright © 2019 Segment. All rights reserved.
+//
+
+#ifndef SEGMacros_h
+#define SEGMacros_h
+
+
+#endif /* SEGMacros_h */

--- a/Analytics/Classes/Internal/SEGMacros.h
+++ b/Analytics/Classes/Internal/SEGMacros.h
@@ -9,5 +9,14 @@
 #ifndef SEGMacros_h
 #define SEGMacros_h
 
+#define __deprecated__(s) __attribute__((deprecated(s)))
+
+#define weakify(var) __weak typeof(var) __weak_##var = var;
+
+#define strongify(var) \
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wshadow\"") \
+__strong typeof(var) var = __weak_##var; \
+_Pragma("clang diagnostic pop")
 
 #endif /* SEGMacros_h */

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -7,6 +7,7 @@
 #import "SEGReachability.h"
 #import "SEGHTTPClient.h"
 #import "SEGStorage.h"
+#import "SEGMacros.h"
 
 #if TARGET_OS_IOS
 #import <CoreTelephony/CTCarrier.h>
@@ -218,14 +219,18 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
 - (NSDictionary *)cachedStaticContext {
     __block NSDictionary *result = nil;
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    weakify(self);
+    dispatch_sync(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        strongify(self);
         result = self._cachedStaticContext;
     });
     return result;
 }
 
 - (void)setCachedStaticContext:(NSDictionary *)cachedStaticContext {
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    weakify(self);
+    dispatch_sync(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        strongify(self);
         self._cachedStaticContext = cachedStaticContext;
     });
 }

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -120,7 +120,7 @@ static BOOL GetAdTrackingEnabled()
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(updateStaticContext)
                                                      name:UIApplicationWillEnterForegroundNotification
-                                                   object:[UIApplication sharedApplication]];
+                                                   object:nil];
     }
     return self;
 }

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -53,7 +53,7 @@ static BOOL GetAdTrackingEnabled()
 @interface SEGSegmentIntegration ()
 
 @property (nonatomic, strong) NSMutableArray *queue;
-@property (nonatomic, strong) NSDictionary *cachedStaticContext;
+@property (nonatomic, strong) NSDictionary *_cachedStaticContext;
 @property (nonatomic, strong) NSURLSessionUploadTask *batchRequest;
 @property (nonatomic, assign) UIBackgroundTaskIdentifier flushTaskID;
 @property (nonatomic, strong) SEGReachability *reachability;
@@ -115,6 +115,12 @@ static BOOL GetAdTrackingEnabled()
         
         [NSRunLoop.mainRunLoop addTimer:self.flushTimer
                                 forMode:NSDefaultRunLoopMode];
+        
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(updateStaticContext)
+                                                     name:UIApplicationWillEnterForegroundNotification
+                                                   object:[UIApplication sharedApplication]];
     }
     return self;
 }
@@ -203,6 +209,25 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 #endif
 
     return dict;
+}
+
+- (void)updateStaticContext
+{
+    self.cachedStaticContext = [self staticContext];
+}
+
+- (NSDictionary *)cachedStaticContext {
+    __block NSDictionary *result = nil;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        result = self._cachedStaticContext;
+    });
+    return result;
+}
+
+- (void)setCachedStaticContext:(NSDictionary *)cachedStaticContext {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        self._cachedStaticContext = cachedStaticContext;
+    });
 }
 
 - (NSDictionary *)liveContext

--- a/Analytics/Classes/Internal/SEGUtils.m
+++ b/Analytics/Classes/Internal/SEGUtils.m
@@ -37,10 +37,6 @@
 
 +(id)traverseJSON:(id)object andReplaceWithFilters:(NSDictionary<NSString*, NSString*>*)patterns
 {
-    if (object == nil || object == NSNull.null || [object isKindOfClass:NSNull.class]) {
-        return object;
-    }
-    
     if ([object isKindOfClass:NSDictionary.class]) {
         NSDictionary* dict = object;
         NSMutableDictionary* newDict = [NSMutableDictionary dictionaryWithCapacity:dict.count];


### PR DESCRIPTION
**What does this PR do?**
- Break out the set/get of the cachedStaticContext
- Respond to ApplicationWillEnterForeground so we can update said context.
- Put locking around static context access.
- Removed extraneous NSNull checks that were causing tests to fail.

**What are the relevant tickets?**
LIB-1522

**Questions:**
- Does the docs need an update?
NO

- Are there any security concerns?
NO

- Do we need to update engineering / success?
NO
