### PR TITLE
Make SEGHTTPClient URLs configurable via SEGAnalyticsConfiguration

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		6EEC1C712017EA370089C478 /* EndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEC1C702017EA370089C478 /* EndToEndTests.swift */; };
 		A31958EF2385AC3A00A47EFA /* SerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A31958EE2385AC3A00A47EFA /* SerializationTests.m */; };
 		A352176023AD5825005B07F6 /* SEGMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A352175F23AD5825005B07F6 /* SEGMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		734E0DD223C82E8200E08CDE /* SEGHTTPConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 734E0DD023C82E8200E08CDE /* SEGHTTPConfiguration.h */; };
+		734E0DD323C82E8200E08CDE /* SEGHTTPConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 734E0DD123C82E8200E08CDE /* SEGHTTPConfiguration.m */; };
 		EA88A5981DED7608009FB66A /* SEGSerializableValue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA88A5971DED7608009FB66A /* SEGSerializableValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA8F09741E24C5C600B8B93F /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8F09731E24C5C600B8B93F /* MiddlewareTests.swift */; };
 		EAA542771EB4035400945DA7 /* TrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA542761EB4035400945DA7 /* TrackingTests.swift */; };
@@ -93,6 +95,8 @@
 		1DF03A6929EEFE7158913224 /* Pods-AnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AnalyticsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AnalyticsTests/Pods-AnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsManagerTest.swift; sourceTree = "<group>"; };
 		6EEC1C702017EA370089C478 /* EndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndToEndTests.swift; sourceTree = "<group>"; };
+		734E0DD023C82E8200E08CDE /* SEGHTTPConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEGHTTPConfiguration.h; sourceTree = "<group>"; };
+		734E0DD123C82E8200E08CDE /* SEGHTTPConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SEGHTTPConfiguration.m; sourceTree = "<group>"; };
 		89033CBF22319674E6CE7E61 /* Pods_AnalyticsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AnalyticsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A31958EE2385AC3A00A47EFA /* SerializationTests.m */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = SerializationTests.m; sourceTree = "<group>"; tabWidth = 4; };
 		A352175F23AD5825005B07F6 /* SEGMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEGMacros.h; sourceTree = "<group>"; };
@@ -352,6 +356,8 @@
 				A352175F23AD5825005B07F6 /* SEGMacros.h */,
 				EADEB8A21DECD12B005322DA /* UIViewController+SEGScreen.h */,
 				EADEB8A31DECD12B005322DA /* UIViewController+SEGScreen.m */,
+				734E0DD023C82E8200E08CDE /* SEGHTTPConfiguration.h */,
+				734E0DD123C82E8200E08CDE /* SEGHTTPConfiguration.m */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -409,6 +415,7 @@
 				EADEB8BF1DECD12B005322DA /* SEGTrackPayload.h in Headers */,
 				EADEB8C71DECD12B005322DA /* SEGHTTPClient.h in Headers */,
 				EADEB8B31DECD12B005322DA /* SEGGroupPayload.h in Headers */,
+				734E0DD223C82E8200E08CDE /* SEGHTTPConfiguration.h in Headers */,
 				EADEB8B01DECD12B005322DA /* SEGCrypto.h in Headers */,
 				EADEB8DE1DECD12B005322DA /* SEGAnalyticsConfiguration.h in Headers */,
 				EADEB8D61DECD12B005322DA /* UIViewController+SEGScreen.h in Headers */,
@@ -594,6 +601,7 @@
 				EADEB8BC1DECD12B005322DA /* SEGPayload.m in Sources */,
 				EADEB8C21DECD12B005322DA /* NSData+SEGGZIP.m in Sources */,
 				EADEB8D91DECD12B005322DA /* SEGContext.m in Sources */,
+				734E0DD323C82E8200E08CDE /* SEGHTTPConfiguration.m in Sources */,
 				EADEB8DB1DECD12B005322DA /* SEGMiddleware.m in Sources */,
 				EADEB8DF1DECD12B005322DA /* SEGAnalyticsConfiguration.m in Sources */,
 				EADEB8D51DECD12B005322DA /* SEGUtils.m in Sources */,

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -70,7 +70,8 @@ static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
         self.configuration = configuration;
         self.serialQueue = seg_dispatch_queue_create_specific("io.segment.analytics", DISPATCH_QUEUE_SERIAL);
         self.messageQueue = [[NSMutableArray alloc] init];
-        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory];
+        self.httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:configuration.requestFactory
+                                                      httpConfiguration:configuration.httpConfiguration];
 #if TARGET_OS_TV
         self.storage = [[SEGUserDefaultsStorage alloc] initWithDefaults:[NSUserDefaults standardUserDefaults] namespacePrefix:nil crypto:configuration.crypto];
 #else

--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -1,15 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "SEGAnalytics.h"
 
-// TODO: Make this configurable via SEGAnalyticsConfiguration
-// NOTE: `/` at the end kind of screws things up. So don't use it
-//#define SEGMENT_API_BASE [NSURL URLWithString:@"https://api-segment-io-5fsaj1xnikhp.runscope.net/v1"]
-//#define SEGMENT_CDN_BASE [NSURL URLWithString:@"https://cdn-segment-com-5fsaj1xnikhp.runscope.net/v1"]
-//#define MOBILE_SERVICE_BASE [NSURL URLWithString:@"https://mobile--service-segment-com-5fsaj1xnikhp.runscope.net/v1"]
-#define SEGMENT_API_BASE [NSURL URLWithString:@"https://api.segment.io/v1"]
-#define SEGMENT_CDN_BASE [NSURL URLWithString:@"https://cdn-settings.segment.com/v1"]
-#define MOBILE_SERVICE_BASE [NSURL URLWithString:@"https://mobile-service.segment.com/v1"]
-
 NS_ASSUME_NONNULL_BEGIN
 
 
@@ -23,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (SEGRequestFactory)defaultRequestFactory;
 + (NSString *)authorizationHeader:(NSString *)writeKey;
 
-- (instancetype)initWithRequestFactory:(SEGRequestFactory _Nullable)requestFactory;
+- (instancetype)initWithRequestFactory:(SEGRequestFactory _Nullable)requestFactory
+                     httpConfiguration:(SEGHTTPConfiguration * _Nonnull)httpConfiguration;
 
 /**
  * Upload dictionary formatted as per https://segment.com/docs/sources/server/http/#batch.

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -2,6 +2,9 @@
 #import "NSData+SEGGZIP.h"
 #import "SEGAnalyticsUtils.h"
 
+@interface SEGHTTPClient()
+@property (nonatomic, strong, nonnull) SEGHTTPConfiguration *httpConfiguration;
+@end
 
 @implementation SEGHTTPClient
 
@@ -21,8 +24,10 @@
 
 
 - (instancetype)initWithRequestFactory:(SEGRequestFactory)requestFactory
+                     httpConfiguration:(SEGHTTPConfiguration *)httpConfiguration
 {
     if (self = [self init]) {
+        _httpConfiguration = httpConfiguration;
         if (requestFactory == nil) {
             self.requestFactory = [SEGHTTPClient defaultRequestFactory];
         } else {
@@ -71,7 +76,7 @@
     //    batch = SEGCoerceDictionary(batch);
     NSURLSession *session = [self sessionForWriteKey:writeKey];
 
-    NSURL *url = [SEGMENT_API_BASE URLByAppendingPathComponent:@"batch"];
+    NSURL *url = [_httpConfiguration.apiBaseURL URLByAppendingPathComponent:@"batch"];
     NSMutableURLRequest *request = self.requestFactory(url);
 
     // This is a workaround for an IOS 8.3 bug that causes Content-Type to be incorrectly set
@@ -140,7 +145,7 @@
 {
     NSURLSession *session = self.genericSession;
 
-    NSURL *url = [SEGMENT_CDN_BASE URLByAppendingPathComponent:[NSString stringWithFormat:@"/projects/%@/settings", writeKey]];
+    NSURL *url = [_httpConfiguration.cdnBaseURL URLByAppendingPathComponent:[NSString stringWithFormat:@"/projects/%@/settings", writeKey]];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"GET"];
 
@@ -177,7 +182,7 @@
 {
     NSURLSession *session = [self sessionForWriteKey:writeKey];
 
-    NSURL *url = [MOBILE_SERVICE_BASE URLByAppendingPathComponent:@"/attribution"];
+    NSURL *url = [_httpConfiguration.mobileServiceBaseURL URLByAppendingPathComponent:@"/attribution"];
     NSMutableURLRequest *request = self.requestFactory(url);
     [request setHTTPMethod:@"POST"];
 

--- a/Analytics/Classes/Internal/SEGHTTPConfiguration.h
+++ b/Analytics/Classes/Internal/SEGHTTPConfiguration.h
@@ -1,0 +1,38 @@
+//
+//  SEGHTTPConfiguration.h
+//  Analytics
+//
+//  Created by Lachlan Anderson on 10/1/20.
+//  Copyright © 2020 Segment. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SEGHTTPConfiguration : NSObject
+
+/// The segment API base URL
+@property (nonatomic, strong, nonnull) NSURL *apiBaseURL;
+
+/// The segment CDN base URL
+@property (nonatomic, strong, nonnull) NSURL *cdnBaseURL;
+
+/// The mobile service base URL
+@property (nonatomic, strong, nonnull) NSURL *mobileServiceBaseURL;
+
+
+/// Will initialise SEGHTTPConfiguration with the default values
++ (SEGHTTPConfiguration * __nonnull)defaults;
+
+/// Will initialise SEGHTTPConfiguration with the specified values
+/// @param apiBaseURL The segment API base URL
+/// @param cdnBaseURL The CDN base URl
+/// @param mobileServiceBaseURL The mobile service base URL
+- (instancetype __nonnull)initWithAPIBaseURL:(NSURL * __nullable)apiBaseURL
+                                  cdnBaseURL:(NSURL * __nullable)cdnBaseURL
+                        mobileServiceBaseURL:(NSURL * __nullable)mobileServiceBaseURL;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Analytics/Classes/Internal/SEGHTTPConfiguration.m
+++ b/Analytics/Classes/Internal/SEGHTTPConfiguration.m
@@ -1,0 +1,36 @@
+//
+//  SEGHTTPConfiguration.m
+//  Analytics
+//
+//  Created by Lachlan Anderson on 10/1/20.
+//  Copyright © 2020 Segment. All rights reserved.
+//
+
+#import "SEGHTTPConfiguration.h"
+
+#define DEFAULT_API_BASE [NSURL URLWithString:@"https://api.segment.io/v1"]
+#define DEFAULT_CDN_BASE [NSURL URLWithString:@"https://cdn-settings.segment.com/v1"]
+#define DEFAULT_MOBILE_SERVICE_BASE [NSURL URLWithString:@"https://mobile-service.segment.com/v1"]
+
+@implementation SEGHTTPConfiguration
+
++ (SEGHTTPConfiguration *)defaults
+{
+    return [[SEGHTTPConfiguration alloc] initWithAPIBaseURL:DEFAULT_API_BASE
+                                                 cdnBaseURL:DEFAULT_CDN_BASE mobileServiceBaseURL:DEFAULT_MOBILE_SERVICE_BASE];
+}
+
+
+- (instancetype)initWithAPIBaseURL:(NSURL *)apiBaseURL
+                        cdnBaseURL:(NSURL *)cdnBaseURL
+              mobileServiceBaseURL:(NSURL *)mobileServiceBaseURL
+{
+    if ((self = [super init])) {
+        _apiBaseURL = apiBaseURL ?: DEFAULT_API_BASE;
+        _cdnBaseURL = cdnBaseURL ?: DEFAULT_CDN_BASE;
+        _mobileServiceBaseURL = mobileServiceBaseURL ?: DEFAULT_MOBILE_SERVICE_BASE;
+    }
+    return self;
+}
+
+@end

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -84,7 +84,7 @@ static BOOL GetAdTrackingEnabled()
         self.httpClient = httpClient;
         self.httpClient.httpSessionDelegate = analytics.configuration.httpSessionDelegate;
         self.storage = storage;
-        self.apiURL = [SEGMENT_API_BASE URLByAppendingPathComponent:@"import"];
+        self.apiURL = [analytics.configuration.httpConfiguration.apiBaseURL URLByAppendingPathComponent:@"import"];
         self.userId = [self getUserId];
         self.reachability = [SEGReachability reachabilityWithHostname:@"google.com"];
         [self.reachability startNotifier];

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "SEGHTTPConfiguration.h"
 
 @protocol SEGApplicationProtocol <NSObject>
 @property (nullable, nonatomic, assign) id<UIApplicationDelegate> delegate;
@@ -114,6 +115,11 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
  * Dictionary indicating the options the app was launched with.
  */
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
+
+/**
+ * Set a custom HTTP configuration.
+ */
+@property (nonatomic, strong, nonnull) SEGHTTPConfiguration *httpConfiguration;
 
 /**
  * Set a custom request factory.


### PR DESCRIPTION
**What does this PR do?**
Make SEGHTTPClient URLs configurable via SEGAnalyticsConfiguration

**Where should the reviewer start?**
SEGHTTPConfiguration

**How should this be manually tested?**
Set SEGHTTPConfiguration within SEGAnalyticsConfiguration & ensure modified URLs are hit

**Any background context you want to provide?**
I wanted to modify the Segment URLs for automated local testing and to allow requests to be sent to another endpoint, or to a proxy for testing.
When inspecting SEGHTTPClient I found the following:
"TODO: Make this configurable via SEGAnalyticsConfiguration"
I did it.

**What are the relevant tickets?**
N/A

**Screenshots or screencasts (if UI/UX change)**
N/A

**Questions:**
- Does the docs need an update?
Negative
- Are there any security concerns?
Negative
- Do we need to update engineering / success?
Negative.
