### PR TITLE
Address Issue #851; Expect dictionary as well for for integration enablement

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -425,8 +425,10 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
         if ([value isKindOfClass:[NSNumber class]]) {
             NSNumber *numberValue = (NSNumber *)value;
             return [numberValue boolValue];
+        } if ([value isKindOfClass:[NSDictionary class]]) {
+            return YES;
         } else {
-            NSString *msg = [NSString stringWithFormat: @"Value for `%@` in integration options is supposed to be a boolean and it is not!"
+            NSString *msg = [NSString stringWithFormat: @"Value for `%@` in integration options is supposed to be a boolean or dictionary and it is not!"
                              "This is likely due to a user-added value in `integrations` that overwrites a value received from the server", key];
             SEGLog(msg);
             NSAssert(NO, msg);

--- a/AnalyticsTests/IntegrationsManagerTest.swift
+++ b/AnalyticsTests/IntegrationsManagerTest.swift
@@ -9,6 +9,18 @@ class IntegrationsManagerTest: QuickSpec {
     describe("IntegrationsManager") {
       context("is track event enabled for integration in plan") {
         
+        it("valid value types are used in integration enablement flags") {
+          var exception: NSException? = nil
+          SwiftTryCatch.tryRun({
+            SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["comScore": ["blah": 1]])
+            SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["comScore": true])
+          }, catchRun: { e in
+            exception = e
+          }, finallyRun: nil)
+          
+          expect(exception).to(beNil())
+        }
+        
         it("asserts when invalid value types are used integration enablement flags") {
           var exception: NSException? = nil
           SwiftTryCatch.tryRun({
@@ -23,7 +35,8 @@ class IntegrationsManagerTest: QuickSpec {
         it("asserts when invalid value types are used integration enablement flags") {
           var exception: NSException? = nil
           SwiftTryCatch.tryRun({
-            SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["comScore": ["key": 1]])
+            // we don't accept array's as values.
+            SEGIntegrationsManager.isIntegration("comScore", enabledInOptions: ["comScore": ["key", 1]])
           }, catchRun: { e in
             exception = e
           }, finallyRun: nil)


### PR DESCRIPTION
**What does this PR do?**

- Correctly supports previously documented behavior.
- A dictionary being supplied into integrations defaults enablement to TRUE.
- Bool still functions as expected.
