### PR TITLE
Publish filenames used for data storage

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.h
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.h
@@ -10,6 +10,12 @@
 #import "SEGMiddleware.h"
 
 /**
+ * Filenames of "Application Support" files where essential data is stored.
+ */
+extern NSString *_Nonnull const kSEGAnonymousIdFilename;
+extern NSString *_Nonnull const kSEGCachedSettingsFilename;
+
+/**
  * NSNotification name, that is posted after integrations are loaded.
  */
 extern NSString *_Nonnull SEGAnalyticsIntegrationDidStart;

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -26,9 +26,9 @@
 #import "SEGAliasPayload.h"
 
 NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.did.start";
-static NSString *const SEGAnonymousIdKey = @"SEGAnonymousId";
-static NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
-static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
+NSString *const SEGAnonymousIdKey = @"SEGAnonymousId";
+NSString *const kSEGAnonymousIdFilename = @"segment.anonymousId";
+NSString *const kSEGCachedSettingsFilename = @"analytics.settings.v2.plist";
 
 
 @interface SEGAnalyticsConfiguration (Private)
@@ -331,9 +331,9 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
 {
     if (!_cachedSettings) {
 #if TARGET_OS_TV
-        _cachedSettings = [self.userDefaultsStorage dictionaryForKey:SEGCachedSettingsKey] ?: @{};
+        _cachedSettings = [self.userDefaultsStorage dictionaryForKey:kSEGCachedSettingsFilename] ?: @{};
 #else
-        _cachedSettings = [self.fileStorage dictionaryForKey:SEGCachedSettingsKey] ?: @{};
+        _cachedSettings = [self.fileStorage dictionaryForKey:kSEGCachedSettingsFilename] ?: @{};
 #endif
     }
     
@@ -349,9 +349,9 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
     }
     
 #if TARGET_OS_TV
-    [self.userDefaultsStorage setDictionary:_cachedSettings forKey:SEGCachedSettingsKey];
+    [self.userDefaultsStorage setDictionary:_cachedSettings forKey:kSEGCachedSettingsFilename];
 #else
-    [self.fileStorage setDictionary:_cachedSettings forKey:SEGCachedSettingsKey];
+    [self.fileStorage setDictionary:_cachedSettings forKey:kSEGCachedSettingsFilename];
 #endif
 
     [self updateIntegrationsWithSettings:settings[@"integrations"]];

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.h
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.h
@@ -9,6 +9,13 @@ extern NSString *const SEGSegmentDidSendRequestNotification;
 extern NSString *const SEGSegmentRequestDidSucceedNotification;
 extern NSString *const SEGSegmentRequestDidFailNotification;
 
+/**
+ * Filenames of "Application Support" files where essential data is stored.
+ */
+extern NSString *const kSEGUserIdFilename;
+extern NSString *const kSEGQueueFilename;
+extern NSString *const kSEGTraitsFilename;
+
 
 @interface SEGSegmentIntegration : NSObject <SEGIntegration>
 


### PR DESCRIPTION
**What does this PR do?**
Makes filenames used for data storage public.

**Where should the reviewer start?**
It's very short.

**How should this be manually tested?**
I don't think there's anything to test.

**Any background context you want to provide?**
Yes, so I need those filenames to be public since my application often starts before a device is unlocked. In such cases Segment library is booted but it fails to read its files/data and then reports analytic events without a `user_id`. Moreover, during such "corrupted" sessions it's using a new `anonymous_id`.

A followup-fix on my application side will be to change `FileProtectionType` of the library files to `.none`. I'm not sure if that's something you'd like to do for all your users, so this PR only publishes those file names.

**What are the relevant tickets?**
n/a

**Screenshots or screencasts (if UI/UX change)**
n/a

**Questions:**
- Does the docs need an update? I added docs for the `const`s which I made public.
- Are there any security concerns? No.
- Do we need to update engineering / success? TBH, I don't understand the question. That said, you guys might want to do two things:
1) Group all your files in `com.segment.analytics` directory within `Application Support` directory. Just to clean up / separate things a bit.
2) Set `FileProtectionType` of all your files to `.none` or... figure out which files are needed during boot-time and which can be accessed later (when a device is unlocked).