### PR TITLE
LIB-1634: Fallback to last settings loaded on iOS

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -394,14 +394,19 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
                 if (success) {
                     [self setCachedSettings:settings];
                 } else {
-                    // If settings request fail, fall back to using just Segment integration.
-                    // Doesn't address situations where this callback never gets called (though we don't expect that to ever happen).
-                    [self setCachedSettings:@{
-                        @"integrations" : @{
-                            @"Segment.io" : @{@"apiKey" : self.configuration.writeKey},
-                        },
-                        @"plan" : @{@"track" : @{}}
-                    }];
+                    NSDictionary *previouslyCachedSettings = [self cachedSettings];
+                    if (previouslyCachedSettings) {
+                        [self setCachedSettings:previouslyCachedSettings];
+                    } else {
+                        // If settings request fail, fall back to using just Segment integration.
+                        // Doesn't address situations where this callback never gets called (though we don't expect that to ever happen).
+                        [self setCachedSettings:@{
+                            @"integrations" : @{
+                                @"Segment.io" : @{@"apiKey" : self.configuration.writeKey},
+                            },
+                            @"plan" : @{@"track" : @{}}
+                        }];
+                    }
                 }
                 self.settingsRequest = nil;
             });


### PR DESCRIPTION
- Uses previously cached settings if unable to retrieve from server.
- Settings were being cached already, just not used.
- If no settings are present (server or cached), fallback to the barebones config.