### PR TITLE
Implement maximum batch request size

### DIFF
--- a/Analytics/Classes/Internal/SEGHTTPClient.h
+++ b/Analytics/Classes/Internal/SEGHTTPClient.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  * NOTE: You need to re-dispatch within the completionHandler onto a desired queue to avoid threading issues.
  * Completion handlers are called on a dispatch queue internal to SEGHTTPClient. 
  */
-- (NSURLSessionUploadTask *)upload:(JSON_DICT)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler;
+- (nullable NSURLSessionUploadTask *)upload:(JSON_DICT)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler;
 
 - (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, JSON_DICT _Nullable settings))completionHandler;
 

--- a/Analytics/Classes/Internal/SEGHTTPClient.m
+++ b/Analytics/Classes/Internal/SEGHTTPClient.m
@@ -2,7 +2,7 @@
 #import "NSData+SEGGZIP.h"
 #import "SEGAnalyticsUtils.h"
 
-static const NSUInteger kMaxBatchSize = 500000; // 500KB
+static const NSUInteger kMaxBatchSize = 475000; // 475KB
 
 @implementation SEGHTTPClient
 
@@ -94,12 +94,12 @@ static const NSUInteger kMaxBatchSize = 500000; // 500KB
         completionHandler(NO); // Don't retry this batch.
         return nil;
     }
-    NSData *gzippedPayload = [payload seg_gzippedData];
-    if (gzippedPayload.length >= kMaxBatchSize) {
+    if (payload.length >= kMaxBatchSize) {
         SEGLog(@"Payload exceeded the limit of %luKB per batch", kMaxBatchSize / 1000);
         completionHandler(NO);
         return nil;
     }
+    NSData *gzippedPayload = [payload seg_gzippedData];
 
     NSURLSessionUploadTask *task = [session uploadTaskWithRequest:request fromData:gzippedPayload completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response, NSError *_Nullable error) {
         if (error) {

--- a/AnalyticsTests/HTTPClientTest.swift
+++ b/AnalyticsTests/HTTPClientTest.swift
@@ -192,7 +192,7 @@ class HTTPClientTest: QuickSpec {
 
       it("fails when batch size exceeds the max limit size") {
         let oversizedBatch: [String: Any] = ["sentAt":"2016-07-19'T'19:25:06Z",
-                                             "batch": Array(repeating: ["type":"track", "event":"foo"], count: 7000000)]
+                                             "batch": Array(repeating: ["type":"track", "event":"foo"], count: 16000)]
         _ = stubRequest("POST", "https://api.segment.io/v1/batch" as NSString)
           .withHeader("User-Agent", "analytics-ios/" + SEGAnalytics.version())!
           .withJsonGzippedBody(oversizedBatch as AnyObject)

--- a/AnalyticsTests/HTTPClientTest.swift
+++ b/AnalyticsTests/HTTPClientTest.swift
@@ -193,11 +193,6 @@ class HTTPClientTest: QuickSpec {
       it("fails when batch size exceeds the max limit size") {
         let oversizedBatch: [String: Any] = ["sentAt":"2016-07-19'T'19:25:06Z",
                                              "batch": Array(repeating: ["type":"track", "event":"foo"], count: 16000)]
-        _ = stubRequest("POST", "https://api.segment.io/v1/batch" as NSString)
-          .withHeader("User-Agent", "analytics-ios/" + SEGAnalytics.version())!
-          .withJsonGzippedBody(oversizedBatch as AnyObject)
-          .withWriteKey("bar")
-          .andReturn(429)
         var done = false
         let task = client.upload(oversizedBatch, forWriteKey: "bar") { retry in
           expect(retry) == false


### PR DESCRIPTION
**What does this PR do?**
PR implements a check when payload excesses size of 500KB.

**Any background context you want to provide?**
The issue from https://github.com/segmentio/analytics-ios/issues/871

**Questions:**
- Does the docs need an update?