### PR TITLE
Bsneed/timestamps

### DIFF
--- a/Analytics.xcodeproj/xcshareddata/xcschemes/Analytics.xcscheme
+++ b/Analytics.xcodeproj/xcshareddata/xcschemes/Analytics.xcscheme
@@ -62,16 +62,6 @@
                ReferencedContainer = "container:Analytics.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9D8CE58B23EE014E00197D0C"
-               BuildableName = "AnalyticsTestsTVOS.xctest"
-               BlueprintName = "AnalyticsTestsTVOS"
-               ReferencedContainer = "container:Analytics.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Analytics/Classes/Integrations/SEGIdentifyPayload.m
+++ b/Analytics/Classes/Integrations/SEGIdentifyPayload.m
@@ -1,5 +1,8 @@
 #import "SEGIdentifyPayload.h"
 
+@interface SEGIdentifyPayload ()
+@property (nonatomic, readwrite, nullable) NSString *anonymousId;
+@end
 
 @implementation SEGIdentifyPayload
 

--- a/Analytics/Classes/Integrations/SEGPayload.h
+++ b/Analytics/Classes/Integrations/SEGPayload.h
@@ -8,6 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) JSON_DICT context;
 @property (nonatomic, readonly) JSON_DICT integrations;
+@property (nonatomic, strong) NSString *timestamp;
 
 - (instancetype)initWithContext:(JSON_DICT)context integrations:(JSON_DICT)integrations;
 

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.h
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.h
@@ -10,6 +10,7 @@ BOOL serializableDictionaryTypes(NSDictionary *dict);
 
 // Date Utils
 NSString *iso8601FormattedString(NSDate *date);
+NSString *iso8601NanoFormattedString(NSDate *date);
 
 void trimQueue(NSMutableArray *array, NSUInteger size);
 

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -18,7 +18,7 @@ static BOOL kAnalyticsLoggerShowLogs = NO;
     return self;
 }
 
-const __SEG_NANO_MAX_LENGTH = 6;
+const __SEG_NANO_MAX_LENGTH = 9;
 - (NSString * _Nonnull)stringFromDate:(NSDate *)date
 {
     NSCalendar *calendar = [NSCalendar currentCalendar];

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -52,7 +52,7 @@ NSString *GenerateUUIDString()
 
 
 // Date Utils
-NSString *iso8601FormattedString(NSDate *date)
+NSString *iso8601NanoFormattedString(NSDate *date)
 {
     static NSDateFormatter *dateFormatter;
     static dispatch_once_t onceToken;
@@ -62,8 +62,6 @@ NSString *iso8601FormattedString(NSDate *date)
     return [dateFormatter stringFromDate:date];
 }
 
-
-/*// Date Utils
 NSString *iso8601FormattedString(NSDate *date)
 {
     static NSDateFormatter *dateFormatter;
@@ -75,7 +73,7 @@ NSString *iso8601FormattedString(NSDate *date)
         dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     });
     return [dateFormatter stringFromDate:date];
-}*/
+}
 
 
 /** trim the queue so that it contains only upto `max` number of elements. */

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -368,7 +368,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     [dictionary setValue:payload.traits forKey:@"traits"];
-
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
     [self enqueueAction:@"identify" dictionary:dictionary context:payload.context integrations:payload.integrations];
 }
 
@@ -377,6 +377,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     [dictionary setValue:payload.event forKey:@"event"];
     [dictionary setValue:payload.properties forKey:@"properties"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
     [self enqueueAction:@"track" dictionary:dictionary context:payload.context integrations:payload.integrations];
 }
 
@@ -385,6 +386,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     [dictionary setValue:payload.name forKey:@"name"];
     [dictionary setValue:payload.properties forKey:@"properties"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
 
     [self enqueueAction:@"screen" dictionary:dictionary context:payload.context integrations:payload.integrations];
 }
@@ -394,6 +396,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     [dictionary setValue:payload.groupId forKey:@"groupId"];
     [dictionary setValue:payload.traits forKey:@"traits"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
 
     [self enqueueAction:@"group" dictionary:dictionary context:payload.context integrations:payload.integrations];
 }
@@ -403,6 +406,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     [dictionary setValue:payload.theNewId forKey:@"userId"];
     [dictionary setValue:self.userId ?: [self.analytics getAnonymousId] forKey:@"previousId"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
 
     [self enqueueAction:@"alias" dictionary:dictionary context:payload.context integrations:payload.integrations];
 }
@@ -457,9 +461,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 - (void)enqueueAction:(NSString *)action dictionary:(NSMutableDictionary *)payload context:(NSDictionary *)context integrations:(NSDictionary *)integrations
 {
     // attach these parts of the payload outside since they are all synchronous
-    // and the timestamp will be more accurate.
     payload[@"type"] = action;
-    payload[@"timestamp"] = iso8601FormattedString([NSDate date]);
     payload[@"messageId"] = GenerateUUIDString();
 
     [self dispatchBackground:^{

--- a/Analytics/Classes/Middlewares/SEGContext.m
+++ b/Analytics/Classes/Middlewares/SEGContext.m
@@ -55,7 +55,10 @@
     // of immutable data structure without the cost of having to allocate and reallocate
     // objects over and over again.
     SEGContext *context = self.debug ? [self copy] : self;
+    NSString *originalTimestamp = context.payload.timestamp;
     modify(context);
+    context.payload.timestamp = originalTimestamp;
+    
     // TODO: We could probably add some validation here that the newly modified context
     // is actualy valid. For example, `eventType` should match `paylaod` class.
     // or anonymousId should never be null.

--- a/Analytics/Classes/Middlewares/SEGContext.m
+++ b/Analytics/Classes/Middlewares/SEGContext.m
@@ -57,7 +57,9 @@
     SEGContext *context = self.debug ? [self copy] : self;
     NSString *originalTimestamp = context.payload.timestamp;
     modify(context);
-    context.payload.timestamp = originalTimestamp;
+    if (originalTimestamp) {
+        context.payload.timestamp = originalTimestamp;
+    }
     
     // TODO: We could probably add some validation here that the newly modified context
     // is actualy valid. For example, `eventType` should match `paylaod` class.

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -448,7 +448,12 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     if (!self.enabled) {
         return;
     }
-    payload.timestamp = iso8601FormattedString([NSDate date]);
+    
+    if (self.configuration.experimental.nanosecondTimestamps) {
+        payload.timestamp = iso8601NanoFormattedString([NSDate date]);
+    } else {
+        payload.timestamp = iso8601FormattedString([NSDate date]);
+    }
     SEGContext *context = [[[SEGContext alloc] initWithAnalytics:self] modify:^(id<SEGMutableContext> _Nonnull ctx) {
         ctx.eventType = eventType;
         ctx.payload = payload;

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -448,6 +448,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     if (!self.enabled) {
         return;
     }
+    payload.timestamp = iso8601FormattedString([NSDate date]);
     SEGContext *context = [[[SEGContext alloc] initWithAnalytics:self] modify:^(id<SEGMutableContext> _Nonnull ctx) {
         ctx.eventType = eventType;
         ctx.payload = payload;

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -25,6 +25,8 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
 @protocol SEGCrypto;
 @protocol SEGMiddleware;
 
+@class SEGAnalyticsExperimental;
+
 /**
  * This object provides a set of properties to control various policies of the analytics client. Other than `writeKey`, these properties can be changed at any time.
  */
@@ -171,4 +173,23 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
  */
 @property (nonatomic, strong, nullable) id<NSURLSessionDelegate> httpSessionDelegate;
 
+/**
+ Enable experimental features within the Segment Analytics-iOS library.
+ */
+@property (nonatomic, readonly, nonnull) SEGAnalyticsExperimental *experimental;
+
+@end
+
+
+@interface SEGAnalyticsExperimental : NSObject
+/**
+ Experimental support for nanosecond timestamps.  While the segment pipeline doesn't support this yet
+ it can be useful where sub-milisecond precision is needed.  An example of this is at startup, when many events
+ fire at the same time and end up with the same timestamp.  The format is "yyyy-MM-ddTHH:mm:ss.SSSSSSSSS:Z".
+ 
+ This will show up only on the originalTimestamp value as seen in the segment debugger.  To properly sort this, one
+ will need to sort by originalTimestamp as well as timestamp.  This should display events in the exact order they were
+ received.
+ */
+@property (nonatomic, assign) BOOL nanosecondTimestamps;
 @end

--- a/Analytics/Classes/SEGAnalyticsConfiguration.m
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.m
@@ -24,11 +24,15 @@
 
 @end
 
+@implementation SEGAnalyticsExperimental
+@end
+
 
 @interface SEGAnalyticsConfiguration ()
 
 @property (nonatomic, copy, readwrite) NSString *writeKey;
 @property (nonatomic, strong, readonly) NSMutableArray *factories;
+@property (nonatomic, strong) SEGAnalyticsExperimental *experimental;
 
 @end
 
@@ -51,6 +55,7 @@
 - (instancetype)init
 {
     if (self = [super init]) {
+        self.experimental = [[SEGAnalyticsExperimental alloc] init];
         self.shouldUseLocationServices = NO;
         self.enableAdvertisingTracking = YES;
         self.shouldUseBluetooth = NO;

--- a/AnalyticsTests/AnalyticsUtilTests.swift
+++ b/AnalyticsTests/AnalyticsUtilTests.swift
@@ -17,7 +17,7 @@ class AnalyticsUtilTests: QuickSpec {
     it("format NSDate objects to RFC 3339 complaint string") {
       let date = Date(timeIntervalSince1970: 0)
       let formattedString = iso8601FormattedString(date)
-      expect(formattedString) == "1970-01-01T00:00:00.000000Z"
+      expect(formattedString) == "1970-01-01T00:00:00.000Z"
 
       var components = DateComponents()
       components.year = 1992
@@ -31,7 +31,27 @@ class AnalyticsUtilTests: QuickSpec {
       calendar.timeZone = TimeZone(secondsFromGMT: -4 * 60 * 60)!
       let date2 = calendar.date(from: components)!
       let formattedString2 = iso8601FormattedString(date2)
-      expect(formattedString2) == "1992-08-06T11:32:04.335000Z"
+      expect(formattedString2) == "1992-08-06T11:32:04.335Z"
+    }
+
+    it("format NSDate objects to RFC 3339 complaint string w/ nanoseconds") {
+      let date = Date(timeIntervalSince1970: 0)
+      let formattedString = iso8601NanoFormattedString(date)
+      expect(formattedString) == "1970-01-01T00:00:00.000000000Z"
+
+      var components = DateComponents()
+      components.year = 1992
+      components.month = 8
+      components.day = 6
+      components.hour = 7
+      components.minute = 32
+      components.second = 4
+      components.nanosecond = 335000008
+      let calendar = NSCalendar(calendarIdentifier: .gregorian)!
+      calendar.timeZone = TimeZone(secondsFromGMT: -4 * 60 * 60)!
+      let date2 = calendar.date(from: components)!
+      let formattedString2 = iso8601NanoFormattedString(date2)
+      expect(formattedString2) == "1992-08-06T11:32:04.335000008Z"
     }
 
     describe("trimQueue", {

--- a/AnalyticsTests/AnalyticsUtilTests.swift
+++ b/AnalyticsTests/AnalyticsUtilTests.swift
@@ -17,7 +17,7 @@ class AnalyticsUtilTests: QuickSpec {
     it("format NSDate objects to RFC 3339 complaint string") {
       let date = Date(timeIntervalSince1970: 0)
       let formattedString = iso8601FormattedString(date)
-      expect(formattedString) == "1970-01-01T00:00:00.000Z"
+      expect(formattedString) == "1970-01-01T00:00:00.000000Z"
 
       var components = DateComponents()
       components.year = 1992
@@ -31,7 +31,7 @@ class AnalyticsUtilTests: QuickSpec {
       calendar.timeZone = TimeZone(secondsFromGMT: -4 * 60 * 60)!
       let date2 = calendar.date(from: components)!
       let formattedString2 = iso8601FormattedString(date2)
-      expect(formattedString2) == "1992-08-06T11:32:04.335Z"
+      expect(formattedString2) == "1992-08-06T11:32:04.335000Z"
     }
 
     describe("trimQueue", {

--- a/AnalyticsTests/TrackingTests.swift
+++ b/AnalyticsTests/TrackingTests.swift
@@ -56,7 +56,13 @@ class TrackingTests: QuickSpec {
     it("handles track:") {
       analytics.track("User Signup", properties: [
         "method": "SSO"
-        ])
+      ], options: [
+        "context": [
+          "device": [
+            "token": "1234"
+          ]
+        ]
+      ])
       expect(passthrough.lastContext?.eventType) == SEGEventType.track
       let payload = passthrough.lastContext?.payload as? SEGTrackPayload
       expect(payload?.event) == "User Signup"


### PR DESCRIPTION
Problems Addressed:
- Customer notes timestamps don't have enough time granularity at times such as startup when a slew of events are sent in a row.
- Timestamp information can/is lost if supplied to an integration that modifies the context/payload.

Changes: 
- Adds nanoseconds to originalTimestamp as seen in the segment debugger.
- Timestamps are created at event submission by the client code.
- Timestamps are still ISO 8601 compliant, however now use the variation of `yyyy-MM-ddTHH:mm:ss.SSSSSS`
- Context/payload modifications and/or replacement maintain the original timestamp.
- Changes put behind a experimental.nanosecondTimestamps flag that must be enabled.

