### PR TITLE
Added Integration Middleware capabilities

### DIFF
--- a/Analytics.xcodeproj/project.pbxproj
+++ b/Analytics.xcodeproj/project.pbxproj
@@ -536,26 +536,30 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0810;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Segment;
 				TargetAttributes = {
+					9D8CE58B23EE014E00197D0C = {
+						LastSwiftMigration = 1130;
+					};
 					EADEB85A1DECD080005322DA = {
 						CreatedOnToolsVersion = 8.1;
 						ProvisioningStyle = Automatic;
 					};
 					EADEB8691DECD0EF005322DA = {
 						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = EADEB8551DECD080005322DA /* Build configuration list for PBXProject "Analytics" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = EADEB8511DECD080005322DA;
 			productRefGroup = EADEB85C1DECD080005322DA /* Products */;
@@ -822,6 +826,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -831,6 +836,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -838,6 +844,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -881,6 +888,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -890,6 +898,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -897,6 +906,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;

--- a/Analytics.xcodeproj/xcshareddata/xcschemes/Analytics.xcscheme
+++ b/Analytics.xcodeproj/xcshareddata/xcschemes/Analytics.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Analytics.xcodeproj/xcshareddata/xcschemes/AnalyticsTests.xcscheme
+++ b/Analytics.xcodeproj/xcshareddata/xcschemes/AnalyticsTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -563,15 +563,12 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
                 ctx.eventType = eventType;
                 ctx.payload = payload;
             }];
-            NSLog(@"-------");
-            NSLog(@"contextIntegrationBefore = %@", context.payload);
 
             context = [runner run:context callback:nil];
             // if we weren't given args, don't set them.
             if (arguments.count > 0) {
                 newArguments[0] = context.payload;
             }
-            NSLog(@"contextIntegrationAfter = %@", context.payload);
         }
     }
     
@@ -699,7 +696,7 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
         }
         case SEGEventTypeUndefined:
             NSAssert(NO, @"Received context with undefined event type %@", context);
-            NSLog(@"[ERROR]: Received context with undefined event type %@", context);
+            SEGLog(@"[ERROR]: Received context with undefined event type %@", context);
             break;
     }
     next(context);

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -553,29 +553,28 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
 
     if (eventType != SEGEventTypeUndefined) {
         SEGMiddlewareRunner *runner = self.integrationMiddleware[key];
-        SEGPayload *payload = nil;
-        // things like flush have no args.
-        if (arguments.count > 0) {
-            payload = arguments[0];
-        }
-        SEGContext *context = [[[SEGContext alloc] initWithAnalytics:[SEGAnalytics sharedAnalytics]] modify:^(id<SEGMutableContext> _Nonnull ctx) {
-            ctx.eventType = eventType;
-            ctx.payload = payload;
-        }];
-        NSLog(@"-------");
-        NSLog(@"contextIntegrationBefore = %@", context.payload);
+        if (runner.middlewares.count > 0) {
+            SEGPayload *payload = nil;
+            // things like flush have no args.
+            if (arguments.count > 0) {
+                payload = arguments[0];
+            }
+            SEGContext *context = [[[SEGContext alloc] initWithAnalytics:self.analytics] modify:^(id<SEGMutableContext> _Nonnull ctx) {
+                ctx.eventType = eventType;
+                ctx.payload = payload;
+            }];
+            NSLog(@"-------");
+            NSLog(@"contextIntegrationBefore = %@", context.payload);
 
-        context = [runner run:context callback:nil];
-        // if we weren't given args, don't set them.
-        if (arguments.count > 0) {
-            newArguments[0] = context.payload;
+            context = [runner run:context callback:nil];
+            // if we weren't given args, don't set them.
+            if (arguments.count > 0) {
+                newArguments[0] = context.payload;
+            }
+            NSLog(@"contextIntegrationAfter = %@", context.payload);
         }
-        NSLog(@"contextIntegrationAfter = %@", context.payload);
     }
     
-    if (newArguments.count == 0) {
-        return;
-    }
     SEGLog(@"Running: %@ with arguments %@ on integration: %@", NSStringFromSelector(selector), newArguments, key);
     NSInvocation *invocation = [self invocationForSelector:selector arguments:newArguments];
     [invocation invokeWithTarget:integration];

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -24,6 +24,7 @@
 #import "SEGGroupPayload.h"
 #import "SEGScreenPayload.h"
 #import "SEGAliasPayload.h"
+#import "SEGUtils.h"
 
 NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.did.start";
 static NSString *const SEGAnonymousIdKey = @"SEGAnonymousId";
@@ -373,6 +374,9 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
         for (id<SEGIntegrationFactory> factory in self.factories) {
             NSString *key = [factory key];
             NSDictionary *integrationSettings = [projectSettings objectForKey:key];
+            if (isUnitTesting()) {
+                integrationSettings = @{};
+            }
             if (integrationSettings) {
                 id<SEGIntegration> integration = [factory createWithSettings:integrationSettings forAnalytics:self.analytics];
                 if (integration != nil) {

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -486,7 +486,19 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         [payload setValue:[context copy] forKey:@"context"];
 
         SEGLog(@"%@ Enqueueing action: %@", self, payload);
-        [self queuePayload:[payload copy]];
+        
+        NSDictionary *queuePayload = [payload copy];
+        
+        if (self.configuration.experimental.rawSegmentModificationBlock != nil) {
+            NSDictionary *tempPayload = self.configuration.experimental.rawSegmentModificationBlock(queuePayload);
+            if (tempPayload == nil) {
+                SEGLog(@"rawSegmentModificationBlock cannot be used to drop events!");
+            } else {
+                // prevent anything else from modifying it at this point.
+                queuePayload = [tempPayload copy];
+            }
+        }
+        [self queuePayload:queuePayload];
     }];
 }
 

--- a/Analytics/Classes/Internal/SEGUtils.h
+++ b/Analytics/Classes/Internal/SEGUtils.h
@@ -15,3 +15,5 @@
 + (id _Nullable)traverseJSON:(id _Nullable)object andReplaceWithFilters:(nonnull NSDictionary<NSString*, NSString*>*)patterns;
 
 @end
+
+BOOL isUnitTesting();

--- a/Analytics/Classes/Internal/SEGUtils.m
+++ b/Analytics/Classes/Internal/SEGUtils.m
@@ -89,3 +89,14 @@
 }
 
 @end
+
+BOOL isUnitTesting()
+{
+    static dispatch_once_t pred = 0;
+    static BOOL _isUnitTesting = NO;
+    dispatch_once(&pred, ^{
+        NSDictionary *env = [NSProcessInfo processInfo].environment;
+        _isUnitTesting = (env[@"XCTestConfigurationFilePath"] != nil);
+    });
+    return _isUnitTesting;
+}

--- a/Analytics/Classes/Middlewares/SEGContext.h
+++ b/Analytics/Classes/Middlewares/SEGContext.h
@@ -58,8 +58,6 @@ typedef NS_ENUM(NSInteger, SEGEventType) {
 @property (nonatomic, readonly, nonnull) SEGAnalytics *_analytics;
 @property (nonatomic, readonly) SEGEventType eventType;
 
-@property (nonatomic, readonly, nullable) NSString *target;
-
 @property (nonatomic, readonly, nullable) NSString *userId;
 @property (nonatomic, readonly, nullable) NSString *anonymousId;
 @property (nonatomic, readonly, nullable) NSError *error;
@@ -75,7 +73,6 @@ typedef NS_ENUM(NSInteger, SEGEventType) {
 @protocol SEGMutableContext <NSObject>
 
 @property (nonatomic) SEGEventType eventType;
-@property (nonatomic, nullable) NSString *target;
 @property (nonatomic, nullable) NSString *userId;
 @property (nonatomic, nullable) NSString *anonymousId;
 @property (nonatomic, nullable) SEGPayload *payload;

--- a/Analytics/Classes/Middlewares/SEGContext.h
+++ b/Analytics/Classes/Middlewares/SEGContext.h
@@ -58,6 +58,8 @@ typedef NS_ENUM(NSInteger, SEGEventType) {
 @property (nonatomic, readonly, nonnull) SEGAnalytics *_analytics;
 @property (nonatomic, readonly) SEGEventType eventType;
 
+@property (nonatomic, readonly, nullable) NSString *target;
+
 @property (nonatomic, readonly, nullable) NSString *userId;
 @property (nonatomic, readonly, nullable) NSString *anonymousId;
 @property (nonatomic, readonly, nullable) NSError *error;
@@ -73,6 +75,7 @@ typedef NS_ENUM(NSInteger, SEGEventType) {
 @protocol SEGMutableContext <NSObject>
 
 @property (nonatomic) SEGEventType eventType;
+@property (nonatomic, nullable) NSString *target;
 @property (nonatomic, nullable) NSString *userId;
 @property (nonatomic, nullable) NSString *anonymousId;
 @property (nonatomic, nullable) SEGPayload *payload;

--- a/Analytics/Classes/Middlewares/SEGContext.m
+++ b/Analytics/Classes/Middlewares/SEGContext.m
@@ -12,7 +12,6 @@
 @interface SEGContext () <SEGMutableContext>
 
 @property (nonatomic) SEGEventType eventType;
-@property (nonatomic, nullable) NSString *target;
 @property (nonatomic, nullable) NSString *userId;
 @property (nonatomic, nullable) NSString *anonymousId;
 @property (nonatomic, nullable) SEGPayload *payload;
@@ -26,7 +25,7 @@
 
 - (instancetype)init
 {
-    @throw [NSException exceptionWithName:@"Bad Initization"
+    @throw [NSException exceptionWithName:@"Bad Initialization"
                                    reason:@"Please use initWithAnalytics:"
                                  userInfo:nil];
 }
@@ -79,7 +78,6 @@
     ctx.payload = self.payload;
     ctx.error = self.error;
     ctx.debug = self.debug;
-    ctx.target = self.target;
     return ctx;
 }
 

--- a/Analytics/Classes/Middlewares/SEGContext.m
+++ b/Analytics/Classes/Middlewares/SEGContext.m
@@ -12,6 +12,7 @@
 @interface SEGContext () <SEGMutableContext>
 
 @property (nonatomic) SEGEventType eventType;
+@property (nonatomic, nullable) NSString *target;
 @property (nonatomic, nullable) NSString *userId;
 @property (nonatomic, nullable) NSString *anonymousId;
 @property (nonatomic, nullable) SEGPayload *payload;
@@ -78,6 +79,7 @@
     ctx.payload = self.payload;
     ctx.error = self.error;
     ctx.debug = self.debug;
+    ctx.target = self.target;
     return ctx;
 }
 

--- a/Analytics/Classes/Middlewares/SEGMiddleware.h
+++ b/Analytics/Classes/Middlewares/SEGMiddleware.h
@@ -51,8 +51,15 @@ typedef void (^RunMiddlewaresCallback)(BOOL earlyExit, NSArray<id<SEGMiddleware>
 // gonna support that for now to keep things simple. If there is a real need later we'll see then.
 @property (nonnull, nonatomic, readonly) NSArray<id<SEGMiddleware>> *middlewares;
 
-- (void)run:(SEGContext *_Nonnull)context callback:(RunMiddlewaresCallback _Nullable)callback;
+- (SEGContext *)run:(SEGContext *_Nonnull)context callback:(RunMiddlewaresCallback _Nullable)callback;
 
-- (instancetype _Nonnull)initWithMiddlewares:(NSArray<id<SEGMiddleware>> *_Nonnull)middlewares;
+- (instancetype _Nonnull)initWithMiddleware:(NSArray<id<SEGMiddleware>> *_Nonnull)middlewares;
 
+@end
+
+// Container object for middlewares for a specific integration.
+@interface SEGIntegrationMiddleware : NSObject
+@property (nonatomic, strong, nonnull, readonly) NSString *integrationKey;
+@property (nonatomic, strong, nullable, readonly) NSArray<id<SEGMiddleware>> *middleware;
+- (instancetype)initWithKey:(NSString *)integrationKey middleware:(NSArray<id<SEGMiddleware>> *)middleware;
 @end

--- a/Analytics/Classes/Middlewares/SEGMiddleware.h
+++ b/Analytics/Classes/Middlewares/SEGMiddleware.h
@@ -51,7 +51,7 @@ typedef void (^RunMiddlewaresCallback)(BOOL earlyExit, NSArray<id<SEGMiddleware>
 // gonna support that for now to keep things simple. If there is a real need later we'll see then.
 @property (nonnull, nonatomic, readonly) NSArray<id<SEGMiddleware>> *middlewares;
 
-- (SEGContext *)run:(SEGContext *_Nonnull)context callback:(RunMiddlewaresCallback _Nullable)callback;
+- (SEGContext * _Nonnull)run:(SEGContext *_Nonnull)context callback:(RunMiddlewaresCallback _Nullable)callback;
 
 - (instancetype _Nonnull)initWithMiddleware:(NSArray<id<SEGMiddleware>> *_Nonnull)middlewares;
 
@@ -61,5 +61,5 @@ typedef void (^RunMiddlewaresCallback)(BOOL earlyExit, NSArray<id<SEGMiddleware>
 @interface SEGIntegrationMiddleware : NSObject
 @property (nonatomic, strong, nonnull, readonly) NSString *integrationKey;
 @property (nonatomic, strong, nullable, readonly) NSArray<id<SEGMiddleware>> *middleware;
-- (instancetype)initWithKey:(NSString *)integrationKey middleware:(NSArray<id<SEGMiddleware>> *)middleware;
+- (instancetype _Nonnull)initWithKey:(NSString * _Nonnull)integrationKey middleware:(NSArray<id<SEGMiddleware>> * _Nonnull)middleware;
 @end

--- a/Analytics/Classes/Middlewares/SEGMiddleware.m
+++ b/Analytics/Classes/Middlewares/SEGMiddleware.m
@@ -10,6 +10,17 @@
 #import "SEGMiddleware.h"
 
 
+@implementation SEGIntegrationMiddleware
+- (instancetype)initWithKey:(NSString *)integrationKey middleware:(NSArray<id<SEGMiddleware>> *)middleware
+{
+    if (self = [super init]) {
+        _integrationKey = integrationKey;
+        _middleware = middleware;
+    }
+    return self;
+}
+@end
+
 @implementation SEGBlockMiddleware
 
 - (instancetype)initWithBlock:(SEGMiddlewareBlock)block
@@ -30,7 +41,7 @@
 
 @implementation SEGMiddlewareRunner
 
-- (instancetype)initWithMiddlewares:(NSArray<id<SEGMiddleware>> *_Nonnull)middlewares
+- (instancetype)initWithMiddleware:(NSArray<id<SEGMiddleware>> *_Nonnull)middlewares
 {
     if (self = [super init]) {
         _middlewares = middlewares;
@@ -38,29 +49,36 @@
     return self;
 }
 
-- (void)run:(SEGContext *_Nonnull)context callback:(RunMiddlewaresCallback _Nullable)callback
+- (SEGContext *)run:(SEGContext *_Nonnull)context callback:(RunMiddlewaresCallback _Nullable)callback
 {
-    [self runMiddlewares:self.middlewares context:context callback:callback];
+    return [self runMiddlewares:self.middlewares context:context callback:callback];
 }
 
 // TODO: Maybe rename SEGContext to SEGEvent to be a bit more clear?
 // We could also use some sanity check / other types of logging here.
-- (void)runMiddlewares:(NSArray<id<SEGMiddleware>> *_Nonnull)middlewares
+- (SEGContext *)runMiddlewares:(NSArray<id<SEGMiddleware>> *_Nonnull)middlewares
                context:(SEGContext *_Nonnull)context
               callback:(RunMiddlewaresCallback _Nullable)callback
 {
+    __block SEGContext * _Nonnull result = context;
+
     BOOL earlyExit = context == nil;
     if (middlewares.count == 0 || earlyExit) {
         if (callback) {
             callback(earlyExit, middlewares);
         }
-        return;
+        return context;
     }
-
-    [middlewares[0] context:context next:^(SEGContext *_Nullable newContext) {
+    
+    NSLog(@"contextA = %@", [result.payload description]);
+    [middlewares[0] context:result next:^(SEGContext *_Nullable newContext) {
         NSArray *remainingMiddlewares = [middlewares subarrayWithRange:NSMakeRange(1, middlewares.count - 1)];
-        [self runMiddlewares:remainingMiddlewares context:newContext callback:callback];
+        NSLog(@"contextBefore = %@", [result.payload description]);
+        result = [self runMiddlewares:remainingMiddlewares context:newContext callback:callback];
+        NSLog(@"contextAfter = %@", [result.payload description]);
     }];
+    
+    return result;
 }
 
 @end

--- a/Analytics/Classes/Middlewares/SEGMiddleware.m
+++ b/Analytics/Classes/Middlewares/SEGMiddleware.m
@@ -70,12 +70,9 @@
         return context;
     }
     
-    NSLog(@"contextA = %@", [result.payload description]);
     [middlewares[0] context:result next:^(SEGContext *_Nullable newContext) {
         NSArray *remainingMiddlewares = [middlewares subarrayWithRange:NSMakeRange(1, middlewares.count - 1)];
-        NSLog(@"contextBefore = %@", [result.payload description]);
         result = [self runMiddlewares:remainingMiddlewares context:newContext callback:callback];
-        NSLog(@"contextAfter = %@", [result.payload description]);
     }];
     
     return result;

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -52,8 +52,8 @@ static SEGAnalytics *__sharedInstance = nil;
         // TODO: Figure out if this is really the best way to do things here.
         self.integrationsManager = [[SEGIntegrationsManager alloc] initWithAnalytics:self];
 
-        self.runner = [[SEGMiddlewareRunner alloc] initWithMiddlewares:
-                                                       [configuration.middlewares ?: @[] arrayByAddingObject:self.integrationsManager]];
+        self.runner = [[SEGMiddlewareRunner alloc] initWithMiddleware:
+                                                       [configuration.sourceMiddleware ?: @[] arrayByAddingObject:self.integrationsManager]];
 
         // Attach to application state change hooks
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -192,6 +192,9 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
 
 @end
 
+#pragma mark - Experimental
+
+typedef  NSDictionary * _Nonnull (^SEGRawModificationBlock)( NSDictionary * _Nonnull rawPayload);
 
 @interface SEGAnalyticsExperimental : NSObject
 /**
@@ -204,4 +207,12 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
  received.
  */
 @property (nonatomic, assign) BOOL nanosecondTimestamps;
+/**
+ Experimental support for transformation of raw dictionaries prior to being sent to segment.
+ This should generally NOT be used, but is a current stop-gap measure for some customers who need to filter
+ payload data prior to being received by segment.com.  This property will go away in future versions when context
+ object data is made available earlier in the event pipeline.
+ */
+@property (nonatomic, strong, nullable) SEGRawModificationBlock rawSegmentModificationBlock;
+
 @end

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -26,6 +26,7 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
 @protocol SEGMiddleware;
 
 @class SEGAnalyticsExperimental;
+@class SEGIntegrationMiddleware;
 
 /**
  * This object provides a set of properties to control various policies of the analytics client. Other than `writeKey`, these properties can be changed at any time.
@@ -128,9 +129,20 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
 @property (nonatomic, strong, nullable) id<SEGCrypto> crypto;
 
 /**
- * Set custom middlewares. Will be run before all integrations
+ * Set custom middlewares. Will be run before all integrations.
+ *  This property is deprecated in favor of the `sourceMiddleware` property.
  */
-@property (nonatomic, strong, nullable) NSArray<id<SEGMiddleware>> *middlewares;
+@property (nonatomic, strong, nullable) NSArray<id<SEGMiddleware>> *middlewares DEPRECATED_MSG_ATTRIBUTE("Use .sourceMiddleware instead.");
+
+/**
+ * Set custom source middleware. Will be run before all integrations
+ */
+@property (nonatomic, strong, nullable) NSArray<id<SEGMiddleware>> *sourceMiddleware;
+
+/**
+ * Set custom integration middleware. Will be run before the associated integration.
+ */
+@property (nonatomic, strong, nullable) NSArray<SEGIntegrationMiddleware *> *integrationMiddleware;
 
 /**
  * Register a factory that can be used to create an integration.

--- a/Analytics/Classes/SEGAnalyticsConfiguration.m
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.m
@@ -27,7 +27,6 @@
 @implementation SEGAnalyticsExperimental
 @end
 
-
 @interface SEGAnalyticsConfiguration ()
 
 @property (nonatomic, copy, readwrite) NSString *writeKey;
@@ -85,6 +84,18 @@
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<%p:%@, %@>", self, self.class, [self dictionaryWithValuesForKeys:@[ @"writeKey", @"shouldUseLocationServices", @"flushAt" ]]];
+}
+
+// MARK: remove these when `middlewares` property is removed.
+
+- (void)setMiddlewares:(NSArray<id<SEGMiddleware>> *)middlewares
+{
+    self.sourceMiddleware = middlewares;
+}
+
+- (NSArray<id<SEGMiddleware>> *)middlewares
+{
+    return self.sourceMiddleware;
 }
 
 @end

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -26,7 +26,7 @@ class AnalyticsTests: QuickSpec {
 
     beforeEach {
       testMiddleware = TestMiddleware()
-      config.middlewares = [testMiddleware]
+      config.sourceMiddleware = [testMiddleware]
       testApplication = TestApplication()
       config.application = testApplication
       config.trackApplicationLifecycleEvents = true

--- a/AnalyticsTests/MiddlewareTests.swift
+++ b/AnalyticsTests/MiddlewareTests.swift
@@ -95,8 +95,14 @@ class IntegrationMiddlewareTests: QuickSpec {
       
       // pump the runloop until we have a last context.
       // integration middleware is held up until initialization is completed.
-      while (passthrough.lastContext == nil) {
-        RunLoop.current.run(until: Date.distantPast)
+      waitUntil(timeout: 60) { done in
+        let queue = DispatchQueue(label: "test")
+        queue.async {
+          while(passthrough.lastContext == nil) {
+            sleep(1);
+          }
+          done()
+        }
       }
       
       expect(passthrough.lastContext?.eventType) == SEGEventType.identify
@@ -113,8 +119,14 @@ class IntegrationMiddlewareTests: QuickSpec {
       
       // pump the runloop until we have a last context.
       // integration middleware is held up until initialization is completed.
-      while (passthrough.lastContext == nil) {
-        RunLoop.current.run(until: Date.distantPast)
+      waitUntil(timeout: 60) { done in
+        let queue = DispatchQueue(label: "test")
+        queue.async {
+          while(passthrough.lastContext == nil) {
+            sleep(1)
+          }
+          done()
+        }
       }
       
       expect(passthrough.lastContext?.eventType) == SEGEventType.track
@@ -131,14 +143,20 @@ class IntegrationMiddlewareTests: QuickSpec {
       config.integrationMiddleware = [SEGIntegrationMiddleware(key: SEGSegmentIntegrationFactory().key(), middleware: [eatAllCalls, passthrough])]
       let analytics = SEGAnalytics(configuration: config)
       analytics.track("Purchase Success")
-      
+
       // Since we're testing that an event is dropped, the previously used run loop pump won't work here.
       var initialized = false;
       NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: SEGAnalyticsIntegrationDidStart), object: nil, queue: nil) { (notification) in
         initialized = true;
       }
-      while (!initialized) {
-        RunLoop.current.run(until: Date.distantPast)
+      waitUntil(timeout: 60) { done in
+        let queue = DispatchQueue(label: "test")
+        queue.async {
+          while (initialized != true) {
+            sleep(1)
+          }
+          done()
+        }
       }
 
       expect(passthrough.lastContext).to(beNil())

--- a/AnalyticsTests/StoreKitTrackerTests.swift
+++ b/AnalyticsTests/StoreKitTrackerTests.swift
@@ -49,7 +49,7 @@ class StoreKitTrackerTests: QuickSpec {
     beforeEach {
       let config = SEGAnalyticsConfiguration(writeKey: "foobar")
       test = TestMiddleware()
-      config.middlewares = [test]
+      config.sourceMiddleware = [test]
       analytics = SEGAnalytics(configuration: config)
       tracker = SEGStoreKitTracker.trackTransactions(for: analytics)
     }

--- a/AnalyticsTests/TrackingTests.swift
+++ b/AnalyticsTests/TrackingTests.swift
@@ -19,7 +19,7 @@ class TrackingTests: QuickSpec {
     beforeEach {
       let config = SEGAnalyticsConfiguration(writeKey: "QUI5ydwIGeFFTa1IvCBUhxL9PyW5B0jE")
       passthrough = SEGPassthroughMiddleware()
-      config.middlewares = [
+      config.sourceMiddleware = [
         passthrough,
       ]
       analytics = SEGAnalytics(configuration: config)

--- a/AnalyticsTests/Utils/TestUtils.swift
+++ b/AnalyticsTests/Utils/TestUtils.swift
@@ -85,8 +85,8 @@ class JsonGzippedBody : LSMatcher, LSMatcheable {
     }
     
     func matchesJson(_ json: AnyObject) -> Bool {
-        let actualValue : () -> NSObject! = {
-            return json as! NSObject
+        let actualValue : () -> NSObject? = {
+          return (json as! NSObject)
         }
         let failureMessage = FailureMessage()
         let location = SourceLocation()


### PR DESCRIPTION
**What does this PR do?**
- Adds integration middleware capabilities.
- Adds tests for integration middleware.
- Deprecates existing `middleware` property on SEGConfiguration and points users to `sourceMiddleware` instead.  
- `middleware` property has been re-routed to sourceMiddleware if used.
- Modifies tests to use sourceMiddleware.

**How should this be manually tested?**
- Tests cover this functionality, N/A

**What are the relevant tickets?**
LIB-1567

**Questions:**
- Does the docs need an update?
YES
- Are there any security concerns?
NO
- Do we need to update engineering / success?
YES
