### PR TITLE
Fixed a crash in the file storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Carthage
 # itself has no pod dependencies, only our tests do.
 Pods/
 .clang-format
+.idea

--- a/Analytics/Classes/Internal/SEGFileStorage.m
+++ b/Analytics/Classes/Internal/SEGFileStorage.m
@@ -109,10 +109,18 @@
 
 - (nullable NSString *)stringForKey:(NSString *)key
 {
-    NSDictionary *data = [self jsonForKey:key];
-    if (data) {
+    id data = [self jsonForKey:key];
+
+    if (data == nil) {
+        return nil;
+    }
+
+    if ([data isKindOfClass:[NSString class]]) {
+        return data;
+    } else if ([data isKindOfClass:[NSDictionary class]]) {
         return data[key];
     }
+
     return nil;
 }
 


### PR DESCRIPTION
**What does this PR do?**
Fixed a crash in the file storage when trying to get a string stored using old SDK version.

**Where should the reviewer start?**
`SEGFileStorage.m`

**How should this be manually tested?**
You need a version of SDK where the string is converted to Data directly without encapsulating it into the Dictionary object. After that upgrade to the version from the PR and it shouldn't crash.

**Any background context you want to provide?**
To avoid such crashes in the future some migration logic would be helpful.

**What are the relevant tickets?**
No tickets I know about.

**Screenshots or screencasts (if UI/UX change)**
No UI/UX changes.

**Questions:**
- Does the docs need an update?
No.
- Are there any security concerns?
No.

- Do we need to update engineering / success?
No.