### PR TITLE
Add method to put device token

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegration.h
+++ b/Analytics/Classes/Integrations/SEGIntegration.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)receivedRemoteNotification:(NSDictionary *)userInfo;
 - (void)failedToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)registeredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+- (void)putDeviceToken:(NSString *)deviceToken;
 - (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo;
 
 // Callbacks for app state changes

--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -253,6 +253,11 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
     [self callIntegrationsWithSelector:_cmd arguments:@[ deviceToken ] options:nil sync:true];
 }
 
+- (void)putDeviceToken:(NSString *)deviceToken
+{
+    [self callIntegrationsWithSelector:_cmd arguments:@[ deviceToken ] options:nil sync:true];
+}
+
 - (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo
 {
     [self callIntegrationsWithSelector:_cmd arguments:@[ identifier, userInfo ] options:nil sync:true];
@@ -518,6 +523,8 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
         result = SEGEventTypeFailedToRegisterForRemoteNotifications;
     } else if ([selectorString hasPrefix:@"registeredForRemoteNotificationsWithDeviceToken"]) {
         result = SEGEventTypeRegisteredForRemoteNotifications;
+    } else if ([selectorString hasPrefix:@"putDeviceToken"]) {
+        result = SEGEventTypePuttingDeviceToken;
     } else if ([selectorString hasPrefix:@"handleActionWithIdentifier"]) {
         result = SEGEventTypeHandleActionWithForRemoteNotification;
     } else if ([selectorString hasPrefix:@"continueUserActivity"]) {
@@ -678,6 +685,9 @@ static NSString *const SEGCachedSettingsKey = @"analytics.settings.v2.plist";
         case SEGEventTypeRegisteredForRemoteNotifications:
             [self registeredForRemoteNotificationsWithDeviceToken:
                       [(SEGRemoteNotificationPayload *)context.payload deviceToken]];
+            break;
+        case SEGEventTypePuttingDeviceToken:
+            [self putDeviceToken:[(SEGPuttingDeviceTokenPayload *)context.payload deviceToken]];
             break;
         case SEGEventTypeHandleActionWithForRemoteNotification: {
             SEGRemoteNotificationPayload *payload = (SEGRemoteNotificationPayload *)context.payload;

--- a/Analytics/Classes/Integrations/SEGPayload.h
+++ b/Analytics/Classes/Integrations/SEGPayload.h
@@ -58,3 +58,9 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic, strong, nullable) NSData *deviceToken;
 
 @end
+
+@interface SEGPuttingDeviceTokenPayload : SEGPayload
+
+@property (nonatomic, strong, nonnull) NSString *deviceToken;
+
+@end

--- a/Analytics/Classes/Integrations/SEGPayload.m
+++ b/Analytics/Classes/Integrations/SEGPayload.m
@@ -24,6 +24,10 @@
 
 @end
 
+@implementation SEGPuttingDeviceTokenPayload
+
+@end
+
 
 @implementation SEGContinueUserActivityPayload
 

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -426,6 +426,11 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     [self.cachedStaticContext[@"device"] setObject:[token copy] forKey:@"token"];
 }
 
+- (void)putDeviceToken:(NSString *)deviceToken
+{
+    [self.cachedStaticContext[@"device"] setObject:deviceToken forKey:@"token"];
+}
+
 - (void)continueUserActivity:(NSUserActivity *)activity
 {
     if ([activity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {

--- a/Analytics/Classes/Middlewares/SEGContext.h
+++ b/Analytics/Classes/Middlewares/SEGContext.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, SEGEventType) {
     SEGEventTypeReceivedRemoteNotification,
     SEGEventTypeFailedToRegisterForRemoteNotifications,
     SEGEventTypeRegisteredForRemoteNotifications,
+    SEGEventTypePuttingDeviceToken,
     SEGEventTypeHandleActionWithForRemoteNotification,
 
     // Application Lifecycle

--- a/Analytics/Classes/SEGAnalytics.h
+++ b/Analytics/Classes/SEGAnalytics.h
@@ -148,6 +148,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)receivedRemoteNotification:(NSDictionary *)userInfo;
 - (void)failedToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)registeredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+
+/*!
+@method
+
+@abstract
+Manually set a device token (for example when using Firebase Cloud Messaging tokens).
+*/
+- (void)putDeviceToken:(NSString *)deviceToken;
+
+// todo: docs
 - (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo;
 - (void)continueUserActivity:(NSUserActivity *)activity;
 - (void)openURL:(NSURL *)url options:(NSDictionary *)options;

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -342,6 +342,13 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     [self run:SEGEventTypeRegisteredForRemoteNotifications payload:payload];
 }
 
+- (void)putDeviceToken:(NSString *)deviceToken
+{
+    SEGPuttingDeviceTokenPayload *payload = [[SEGPuttingDeviceTokenPayload alloc] init];
+    payload.deviceToken = deviceToken;
+    [self run:SEGEventTypePuttingDeviceToken payload:payload];
+}
+
 - (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo
 {
     SEGRemoteNotificationPayload *payload = [[SEGRemoteNotificationPayload alloc] init];


### PR DESCRIPTION
**What does this PR do?**
This PR adds a method to put device tokens which are utilized by some destinations (e.g. Customer.io). [The Segment Android SDK offers the same functionality.](https://github.com/segmentio/analytics-android/blob/9ad041fbec94424f321758cb73ed2683f3f7f5e5/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java#L443-L447) Setting device tokens (obtained from Firebase Cloud Messaging SDK) enables Customer.io to track devices via Segment which enables their push notification feature.

**How should this be manually tested?**
Call `[SEGAnalytics.sharedAnalytics putDeviceToken:@"i-am-a-device-token"]` and check in Segment’s event debugger if new events contain the `token` key within their `context/device` dictionary.

**Any background context you want to provide?**
We are developing in React Native and are using Firebase Cloud Messaging (via [React Native Firebase](https://rnfirebase.io/)). We want to use Customer.io to send out push notifications, so we are working on a pull request for the Segment React Native SDK to add functionality which is required to make this happen. Before we can continue our work we need a way to set a FCM device token in iOS – hence this pull request.

**What are the relevant tickets?**
#869

**Questions:**
- Does the docs need an update?
  I added comments, but the Segment website ([Analytics for iOS](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/)) might also need one.
- Are there any security concerns?
  I don't think so.
- Do we need to update engineering / success?
  Maybe?
