### PR TITLE
Automatic Screen Tracking with consistent naming conventions

### DIFF
--- a/Analytics/Classes/Internal/UIViewController+SEGScreen.m
+++ b/Analytics/Classes/Internal/UIViewController+SEGScreen.m
@@ -96,9 +96,11 @@
         return;
     }
 
-    NSString *name = [top title];
+    NSString *name = [[[top class] description] stringByReplacingOccurrencesOfString:@"ViewController" withString:@""];
+    
     if (!name || name.length == 0) {
-        name = [[[top class] description] stringByReplacingOccurrencesOfString:@"ViewController" withString:@""];
+        // if no class description found, try view controller's title.
+        name = [top title];
         // Class name could be just "ViewController".
         if (name.length == 0) {
             SEGLog(@"Could not infer screen name.");


### PR DESCRIPTION
**What does this PR do?**
This simply reverses the logic for naming conventions regarding automatic screen tracking in an attempt to provide more consistent naming conventions. The current approach is sacrificing consistency for readability which muddies up data. With the addition of the custom naming protocol, we don't need `title` anymore.

Assuming that all view controllers have a somewhat unique name (other than ViewController which is specified in the logic), we can assume that the automatic screen tracking will have a consistent naming convention throughout all screens (rather than having a mix of both `ClassName` minus "ViewController" and `title`), since all view controllers will not have a `title` i.e `NavigationItem`.

Furthermore, if two view controllers have the same `title`, then they will show up as having the same name value. Using class name is a better way to uniquely identify a screen.

With the addition of the custom naming protocol, title as a first choice naming convention is a bit redundant because you can conform to the protocol if you need a custom or more readable name such as the title of the view controller.


**Where should the reviewer start?**
`UIViewController.seg_viewDidAppear()`

**How should this be manually tested?**
Add `recordScreenViews` to your config, then look at the names of the events reported.

**Any background context you want to provide?**
With the automatic screen tracking feature we want a consistent naming convention without overriding or conforming to protocols.

**What are the relevant tickets?**
Related to #771 

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
Yes

- Are there any security concerns?
No

- Do we need to update engineering/success?
N/A
