### PR TITLE
Added check to count previously cached settings before using it

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -410,7 +410,7 @@ NSString *const kSEGCachedSettingsFilename = @"analytics.settings.v2.plist";
                     [self setCachedSettings:settings];
                 } else {
                     NSDictionary *previouslyCachedSettings = [self cachedSettings];
-                    if (previouslyCachedSettings) {
+                    if (previouslyCachedSettings && [previouslyCachedSettings count] > 0) {
                         [self setCachedSettings:previouslyCachedSettings];
                     } else if (self.configuration.defaultSettings != nil) {
                         // If settings request fail, load a user-supplied version if present.


### PR DESCRIPTION
**What does this PR do?**
Added check to count previously cached settings before using it
**Where should the reviewer start?**
` if (previouslyCachedSettings && [previouslyCachedSettings count] > 0) {`
**How should this be manually tested?**
Verify we can if previously cached settings is empty we fallback to the barebones config
**Any background context you want to provide?**

**What are the relevant tickets?**
https://github.com/segmentio/analytics-ios/issues/887
**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update? No
- Are there any security concerns? No
- Do we need to update engineering / success? No

https://github.com/segmentio/analytics-ios/blob/master/CONTRIBUTING.md - Says to create the PR to `dev` branch but don't see `dev` branch so creating the pr in `master` to branch.