### PR TITLE
Makes IDFA support externally/customer driven.

### DIFF
--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -1,6 +1,5 @@
 #import "SEGAnalyticsUtils.h"
-#import <Analytics/Analytics.h>
-#import <AdSupport/ASIdentifierManager.h>
+#import "SEGAnalytics.h"
 
 static BOOL kAnalyticsLoggerShowLogs = NO;
 

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -1,4 +1,5 @@
 #import "SEGAnalyticsUtils.h"
+#import <Analytics/Analytics.h>
 #import <AdSupport/ASIdentifierManager.h>
 
 static BOOL kAnalyticsLoggerShowLogs = NO;
@@ -217,23 +218,10 @@ NSDictionary *SEGCoerceDictionary(NSDictionary *dict)
 
 NSString *SEGIDFA()
 {
-    NSString *idForAdvertiser = nil;
-    Class identifierManager = NSClassFromString(@"ASIdentifierManager");
-    if (identifierManager) {
-        SEL sharedManagerSelector = NSSelectorFromString(@"sharedManager");
-        id sharedManager =
-            ((id (*)(id, SEL))
-                 [identifierManager methodForSelector:sharedManagerSelector])(
-                identifierManager, sharedManagerSelector);
-        SEL advertisingIdentifierSelector =
-            NSSelectorFromString(@"advertisingIdentifier");
-        NSUUID *uuid =
-            ((NSUUID * (*)(id, SEL))
-                 [sharedManager methodForSelector:advertisingIdentifierSelector])(
-                sharedManager, advertisingIdentifierSelector);
-        idForAdvertiser = [uuid UUIDString];
+    if ([SEGAnalytics sharedAnalytics].configuration.adSupportBlock != nil) {
+        return [SEGAnalytics sharedAnalytics].configuration.adSupportBlock();
     }
-    return idForAdvertiser;
+    return nil;
 }
 
 NSString *SEGEventNameForScreenTitle(NSString *title)

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -174,7 +174,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         if (NSClassFromString(SEGAdvertisingClassIdentifier)) {
             dict[@"adTrackingEnabled"] = @(GetAdTrackingEnabled());
         }
-        if (self.configuration.enableAdvertisingTracking) {
+        if (self.configuration.enableAdvertisingTracking && self.configuration.adSupportBlock != nil) {
             NSString *idfa = SEGIDFA();
             if (idfa.length) dict[@"advertisingId"] = idfa;
         }

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -20,6 +20,7 @@
 @end
 
 typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
+typedef NSString *_Nonnull (^SEGAdSupportBlock)(void);
 
 @protocol SEGIntegrationFactory;
 @protocol SEGCrypto;
@@ -184,6 +185,18 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
  * An optional delegate that handles NSURLSessionDelegate callbacks
  */
 @property (nonatomic, strong, nullable) id<NSURLSessionDelegate> httpSessionDelegate;
+
+/**
+ * Sets a block to be called when IDFA / AdSupport identifier is created.
+ * This is to allow for apps that do not want ad tracking to pass App Store guidelines in certain categories while
+ * still allowing apps that do ad tracking to continue to function.
+ *
+ * Example:
+ *      configuration.adSupportBlock = ^{
+ *          return [[ASIdentifierManager sharedManager] advertisingIdentifier];
+ *      }
+ */
+@property (nonatomic, strong, nullable) SEGAdSupportBlock adSupportBlock;
 
 /**
  Enable experimental features within the Segment Analytics-iOS library.

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -58,7 +58,7 @@ class AnalyticsTests: QuickSpec {
       expect(UserDefaults.standard.string(forKey: "SEGQueue")).toEventually(beNil())
     }
     
-    /* WIP
+    /* TODO: Fix me when the Context object isn't so wild.
     it("collects IDFA") {
       testMiddleware.swallowEvent = true
       analytics.configuration.enableAdvertisingTracking = true
@@ -70,13 +70,12 @@ class AnalyticsTests: QuickSpec {
       
       let event = testMiddleware.lastContext?.payload as? SEGTrackPayload
       expect(event?.properties?["url"] as? String) == "myapp://auth?token=((redacted/my-auth))&other=stuff"
-    }
+    }*/
     
     it("persists anonymousId") {
       let analytics2 = SEGAnalytics(configuration: config)
       expect(analytics.getAnonymousId()) == analytics2.getAnonymousId()
     }
-    */
 
     it("persists userId") {
       analytics.identify("testUserId1")

--- a/AnalyticsTests/AnalyticsTests.swift
+++ b/AnalyticsTests/AnalyticsTests.swift
@@ -58,10 +58,25 @@ class AnalyticsTests: QuickSpec {
       expect(UserDefaults.standard.string(forKey: "SEGQueue")).toEventually(beNil())
     }
     
+    /* WIP
+    it("collects IDFA") {
+      testMiddleware.swallowEvent = true
+      analytics.configuration.enableAdvertisingTracking = true
+      analytics.configuration.adSupportBlock = { () -> String in
+        return "1234AdsNoMore!"
+      }
+
+      analytics.track("test");
+      
+      let event = testMiddleware.lastContext?.payload as? SEGTrackPayload
+      expect(event?.properties?["url"] as? String) == "myapp://auth?token=((redacted/my-auth))&other=stuff"
+    }
+    
     it("persists anonymousId") {
       let analytics2 = SEGAnalytics(configuration: config)
       expect(analytics.getAnonymousId()) == analytics2.getAnonymousId()
     }
+    */
 
     it("persists userId") {
       analytics.identify("testUserId1")


### PR DESCRIPTION
- IDFA is moved completely external.
- Customers must now set a adSupportBlock which will get called (so they can retrieve IDFA, not us).
- References to AdSupport framework have been removed.