### PR TITLE
Backport defaultSettings feature from 4.x to 3.x.

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -423,6 +423,12 @@ NSString *const kSEGCachedSettingsFilename = @"analytics.settings.v2.plist";
                     NSDictionary *previouslyCachedSettings = [self cachedSettings];
                     if (previouslyCachedSettings && [previouslyCachedSettings count] > 0) {
                         [self setCachedSettings:previouslyCachedSettings];
+                    } else if (self.configuration.defaultSettings != nil) {
+                        // If settings request fail, load a user-supplied version if present.
+                        // but make sure segment.io is in the integrations
+                        NSMutableDictionary *newSettings = [self.configuration.defaultSettings serializableMutableDeepCopy];
+                        newSettings[@"integrations"][@"Segment.io"][@"apiKey"] = self.configuration.writeKey;
+                        [self setCachedSettings:newSettings];
                     } else {
                         // If settings request fail, fall back to using just Segment integration.
                         // Doesn't address situations where this callback never gets called (though we don't expect that to ever happen).

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.h
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.h
@@ -36,6 +36,7 @@ NSString *SEGEventNameForScreenTitle(NSString *title);
 
 // Deep copy and check NSCoding conformance
 @protocol SEGSerializableDeepCopy <NSObject>
+-(id _Nullable) serializableMutableDeepCopy;
 -(id _Nullable) serializableDeepCopy;
 @end
 

--- a/Analytics/Classes/Internal/SEGAnalyticsUtils.m
+++ b/Analytics/Classes/Internal/SEGAnalyticsUtils.m
@@ -244,9 +244,9 @@ NSString *SEGEventNameForScreenTitle(NSString *title)
 
 @implementation NSDictionary(SerializableDeepCopy)
 
-- (NSDictionary *)serializableDeepCopy
+- (id)serializableDeepCopy:(BOOL)mutable
 {
-    NSMutableDictionary *returnDict = [[NSMutableDictionary alloc] initWithCapacity:self.count];
+    NSMutableDictionary *result = [[NSMutableDictionary alloc] initWithCapacity:self.count];
     NSArray *keys = [self allKeys];
     for (id key in keys) {
         id aValue = [self objectForKey:key];
@@ -263,17 +263,29 @@ NSString *SEGEventNameForScreenTitle(NSString *title)
         }
         
         if ([aValue conformsToProtocol:@protocol(SEGSerializableDeepCopy)]) {
-            theCopy = [aValue serializableDeepCopy];
+            theCopy = [aValue serializableDeepCopy:mutable];
         } else if ([aValue conformsToProtocol:@protocol(NSCopying)]) {
             theCopy = [aValue copy];
         } else {
             theCopy = aValue;
         }
         
-        [returnDict setValue:theCopy forKey:key];
-  }
+        [result setValue:theCopy forKey:key];
+    }
     
-  return [returnDict copy];
+    if (mutable) {
+        return result;
+    } else {
+        return [result copy];
+    }
+}
+
+- (NSDictionary *)serializableDeepCopy {
+    return [self serializableDeepCopy:NO];
+}
+
+- (NSMutableDictionary *)serializableMutableDeepCopy {
+    return [self serializableDeepCopy:YES];
 }
 
 @end
@@ -281,9 +293,9 @@ NSString *SEGEventNameForScreenTitle(NSString *title)
 
 @implementation NSArray(SerializableDeepCopy)
 
--(NSArray *)serializableDeepCopy
+-(id)serializableDeepCopy:(BOOL)mutable
 {
-    NSMutableArray *returnArray = [[NSMutableArray alloc] initWithCapacity:self.count];
+    NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:self.count];
     
     for (id aValue in self) {
         id theCopy = nil;
@@ -299,16 +311,30 @@ NSString *SEGEventNameForScreenTitle(NSString *title)
         }
         
         if ([aValue conformsToProtocol:@protocol(SEGSerializableDeepCopy)]) {
-            theCopy = [aValue serializableDeepCopy];
+            theCopy = [aValue serializableDeepCopy:mutable];
         } else if ([aValue conformsToProtocol:@protocol(NSCopying)]) {
             theCopy = [aValue copy];
         } else {
             theCopy = aValue;
         }
-        [returnArray addObject:theCopy];
+        [result addObject:theCopy];
     }
     
-    return [returnArray copy];
+    if (mutable) {
+        return result;
+    } else {
+        return [result copy];
+    }
 }
+
+
+- (NSArray *)serializableDeepCopy {
+    return [self serializableDeepCopy:NO];
+}
+
+- (NSMutableArray *)serializableMutableDeepCopy {
+    return [self serializableDeepCopy:YES];
+}
+
 
 @end

--- a/Analytics/Classes/SEGAnalyticsConfiguration.h
+++ b/Analytics/Classes/SEGAnalyticsConfiguration.h
@@ -127,6 +127,13 @@ typedef NSMutableURLRequest *_Nonnull (^SEGRequestFactory)(NSURL *_Nonnull);
  */
 @property (nonatomic, strong, nullable) id<SEGCrypto> crypto;
 
+
+/**
+ * Set the default settings to use if Segment.com cannot be reached. 
+ * An example configuration can be found here, using your write key:  https://cdn-settings.segment.com/v1/projects/YOUR_WRITE_KEY/settings
+ */
+@property (nonatomic, strong, nullable) NSDictionary *defaultSettings;
+
 /**
  * Set custom middlewares. Will be run before all integrations
  */


### PR DESCRIPTION
This PR brings the defaultSettings configuration option and usage logic from the 4.x series back to the 3.x series.  This is necessary to support react native until all device mode integrations have been updated such that they are no longer version pinned to 3.x.