### PR TITLE
Added application object back to notifications

### DIFF
--- a/Analytics/Classes/Integrations/SEGIntegrationsManager.m
+++ b/Analytics/Classes/Integrations/SEGIntegrationsManager.m
@@ -116,7 +116,10 @@ NSString *const kSEGCachedSettingsFilename = @"analytics.settings.v2.plist";
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 
         // Update settings on foreground
-        [nc addObserver:self selector:@selector(onAppForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+        id<SEGApplicationProtocol> application = configuration.application;
+        if (application) {
+            [nc addObserver:self selector:@selector(onAppForeground:) name:UIApplicationWillEnterForegroundNotification object:application];
+        }
     }
     return self;
 }

--- a/Analytics/Classes/SEGAnalytics.m
+++ b/Analytics/Classes/SEGAnalytics.m
@@ -59,13 +59,16 @@ static SEGAnalytics *__sharedInstance = nil;
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 
         // Pass through for application state change events
-        for (NSString *name in @[ UIApplicationDidEnterBackgroundNotification,
-                                  UIApplicationDidFinishLaunchingNotification,
-                                  UIApplicationWillEnterForegroundNotification,
-                                  UIApplicationWillTerminateNotification,
-                                  UIApplicationWillResignActiveNotification,
-                                  UIApplicationDidBecomeActiveNotification ]) {
-            [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:nil];
+        id<SEGApplicationProtocol> application = configuration.application;
+        if (application) {
+            for (NSString *name in @[ UIApplicationDidEnterBackgroundNotification,
+                                      UIApplicationDidFinishLaunchingNotification,
+                                      UIApplicationWillEnterForegroundNotification,
+                                      UIApplicationWillTerminateNotification,
+                                      UIApplicationWillResignActiveNotification,
+                                      UIApplicationDidBecomeActiveNotification ]) {
+                [nc addObserver:self selector:@selector(handleAppStateNotification:) name:name object:application];
+            }
         }
 
         if (configuration.recordScreenViews) {


### PR DESCRIPTION
**What does this PR do?**
Brings back the notification condition for lifecycle events. This limits the amount of notifications sent out to only limit specifically to Segment analytics.