### PR TITLE
Fix SwiftUI previews in macOS Catalyst builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,9 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("Internal"),
                 .headerSearchPath("Classes")
+            ],
+            linkerSettings: [
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS]))
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
                 .headerSearchPath("Classes")
             ],
             linkerSettings: [
-                .linkedFramework("CoreTelephony", .when(platforms: [.iOS]))
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS, .macOS]))
             ]
         ),
     ]


### PR DESCRIPTION
The latest 4.0.2 works on macOS via Catalyst, building through Swift Package Manager, assuming you add CoreTelephony to the list of linked frameworks.

However, if you attempt to view a SwiftUI preview on an app linking Analytics, you'll get the following issue:

```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_CTTelephonyNetworkInfo", referenced from:
      objc-class-ref in Analytics.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

when trying to view the preview. As far as I can tell, SwiftUI previews turn SwiftPM static libraries into dynamic libraries, so they need to fully resolve their linkage at *library* build time, instead of app build time.

Adding CoreTelephony to the linker settings fixes this. It does *not* remove the requirement to add CoreTelephony to the app's list of linked frameworks but it does remove the problems with SwiftUI previews.