### PR TITLE
Disregard payloads that fail conversion from plist to json backing

### DIFF
--- a/Analytics/Internal/SEGFileStorage.m
+++ b/Analytics/Internal/SEGFileStorage.m
@@ -160,11 +160,18 @@
         BOOL needsConversion = NO;
         result = [self jsonFromData:data needsConversion:&needsConversion];
         if (needsConversion) {
-            [self setJSON:result forKey:key];
-            // maybe a little repetitive, but we want to recreate the same path it would
-            // take if it weren't being converted.
-            data = [self dataForKey:key];
-            result = [self jsonFromData:data needsConversion:&needsConversion];
+            @try {
+                [self setJSON:result forKey:key];
+                // maybe a little repetitive, but we want to recreate the same path it would
+                // take if it weren't being converted.
+                data = [self dataForKey:key];
+                result = [self jsonFromData:data needsConversion:&needsConversion];
+            } @catch (NSException *e) {
+                SEGLog(@"Unable to convert data from plist object to json; Exception: %@, data: %@", e, data);
+
+                [self removeKey:key];
+                result = nil;
+            }
         }
     }
     return result;

--- a/AnalyticsTests/FileStorageTest.swift
+++ b/AnalyticsTests/FileStorageTest.swift
@@ -114,6 +114,19 @@ class FileStorageTest : XCTestCase {
         let dictOut = storage.dictionary(forKey: key)
         XCTAssertEqual(dictOut as? [String: String], dictIn)
     }
+
+    func testShouldRemoveDictionaryForInvalidPlistConversion() {
+        let key = "invalid.plist"
+        let dictIn: [String: Any] = [
+          "timestamp": TimeInterval.nan // `.nan` fails JSONSerialization
+        ]
+
+        let url = storage.url(forKey: key)
+        (dictIn as NSDictionary).write(to: url, atomically: true)
+        let dictOut = storage.dictionary(forKey: key)
+        XCTAssertNil(dictOut)
+        XCTAssertNil(try? url.checkResourceIsReachable())
+    }
     
     func testShouldWorkWithCrypto() {
         let url = FileStorage.applicationSupportDirectoryURL()


### PR DESCRIPTION
**What does this PR do?**
- Fixes #924 
- Since clients of v3.8.0+ will need to update to remove invalid JSON values in order to send new events, the changes here "match" the behavior by disregarding any events that can't be converted to valid JSON. Not ideal, but works without requiring support for both plists and json and is consistent in that events emitted from v3.8.0+ will only have values that work in JSONSerialization.

**Where should the reviewer start?**
n/a, pretty small diff here

**How should this be manually tested?**
1. Attempt to track events with `TimeInterval.nan` as values while offline on v3.7.0
2. Upgrade to a version with these changes and avoid a crash

(added some unit tests to approximate this)

**Any background context you want to provide?**
See #924 for more info
