### PR TITLE
[LIBMOBILE-149] Fixed double device payload

### DIFF
--- a/Analytics/Internal/SEGUtils.m
+++ b/Analytics/Internal/SEGUtils.m
@@ -171,11 +171,18 @@ NSDictionary *getStaticContext(SEGAnalyticsConfiguration *configuration, NSStrin
         };
     }
 
+    NSDictionary *settingsDictionary = nil;
 #if TARGET_OS_IPHONE
-    dict[@"device"] = mobileSpecifications(configuration, deviceToken);
+    settingsDictionary = mobileSpecifications(configuration, deviceToken);
 #elif TARGET_OS_OSX
-    dict[@"device"] = desktopSpecifications(configuration, deviceToken);
+    settingsDictionary = desktopSpecifications(configuration, deviceToken);
 #endif
+    
+    if (settingsDictionary != nil) {
+        dict[@"device"] = settingsDictionary[@"device"];
+        dict[@"os"] = settingsDictionary[@"os"];
+        dict[@"screen"] = settingsDictionary[@"screen"];
+    }
 
     return dict;
 }


### PR DESCRIPTION
**What does this PR do?**
Fixes an issue where device was in the payload twice.

**Where should the reviewer start?**
Look at version 4.0.4 vs this PR. 4.0.4 contained the issue, 4.0.3 did not. Compare SEGUtil

**How should this be manually tested?**
Run to see the payload, verify device isn't doubled up.

**Any background context you want to provide?**

**What are the relevant tickets?**
LIBMOBILE-149

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
- Are there any security concerns?
- Do we need to update engineering / success?
