### PR TITLE
Add WebhookIntegration

### DIFF
--- a/Segment.xcodeproj/project.pbxproj
+++ b/Segment.xcodeproj/project.pbxproj
@@ -468,7 +468,6 @@
 				TargetAttributes = {
 					EADEB85A1DECD080005322DA = {
 						CreatedOnToolsVersion = 8.1;
-						LastSwiftMigration = 1200;
 						ProvisioningStyle = Manual;
 					};
 					EADEB8691DECD0EF005322DA = {
@@ -706,7 +705,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
@@ -725,8 +723,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -736,7 +732,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
@@ -755,7 +750,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -764,7 +758,6 @@
 		EADEB8721DECD0EF005322DA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = SegmentTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.segment.AnalyticsTests;
@@ -781,7 +774,6 @@
 		EADEB8731DECD0EF005322DA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = SegmentTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.segment.AnalyticsTests;

--- a/Segment.xcodeproj/project.pbxproj
+++ b/Segment.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		630FC8EA2107F2A500A759C5 /* SEGScreenReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AF0EDFEDC0EE79A0A0EB713 /* SEGScreenReporting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E265C791FB1178C0030E08E /* IntegrationsManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */; };
 		6EEC1C712017EA370089C478 /* EndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEC1C702017EA370089C478 /* EndToEndTests.swift */; };
+		75FD4202252401B500BC8970 /* SEGWebhookIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 75FD4201252401B500BC8970 /* SEGWebhookIntegration.m */; };
+		75FD42052524F1E000BC8970 /* SEGWebhookIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 75FD42002524019100BC8970 /* SEGWebhookIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96A12C2824B680DB00949804 /* NSViewController+SEGScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A12C2624B680DB00949804 /* NSViewController+SEGScreen.h */; };
 		96A12C2924B680DB00949804 /* NSViewController+SEGScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A12C2724B680DB00949804 /* NSViewController+SEGScreen.m */; };
 		A31958EF2385AC3A00A47EFA /* SerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A31958EE2385AC3A00A47EFA /* SerializationTests.m */; };
@@ -101,6 +103,8 @@
 		63E090D722DD49C300DEC7EC /* UIViewController+SegScreenTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+SegScreenTest.h"; sourceTree = "<group>"; };
 		6E265C781FB1178C0030E08E /* IntegrationsManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationsManagerTest.swift; sourceTree = "<group>"; };
 		6EEC1C702017EA370089C478 /* EndToEndTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = EndToEndTests.swift; sourceTree = "<group>"; tabWidth = 4; };
+		75FD42002524019100BC8970 /* SEGWebhookIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEGWebhookIntegration.h; sourceTree = "<group>"; };
+		75FD4201252401B500BC8970 /* SEGWebhookIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SEGWebhookIntegration.m; sourceTree = "<group>"; };
 		96A12C2624B680DB00949804 /* NSViewController+SEGScreen.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSViewController+SEGScreen.h"; sourceTree = "<group>"; };
 		96A12C2724B680DB00949804 /* NSViewController+SEGScreen.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSViewController+SEGScreen.m"; sourceTree = "<group>"; };
 		A31958EE2385AC3A00A47EFA /* SerializationTests.m */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = SerializationTests.m; sourceTree = "<group>"; tabWidth = 4; };
@@ -313,6 +317,8 @@
 				EADEB88B1DECD12B005322DA /* SEGTrackPayload.m */,
 				EADEB88F1DECD12B005322DA /* SEGAnalyticsUtils.h */,
 				EADEB8901DECD12B005322DA /* SEGAnalyticsUtils.m */,
+				75FD42002524019100BC8970 /* SEGWebhookIntegration.h */,
+				75FD4201252401B500BC8970 /* SEGWebhookIntegration.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -395,6 +401,7 @@
 				EADEB8DE1DECD12B005322DA /* SEGAnalyticsConfiguration.h in Headers */,
 				EADEB8D61DECD12B005322DA /* UIViewController+SEGScreen.h in Headers */,
 				EADEB8CF1DECD12B005322DA /* SEGStorage.h in Headers */,
+				75FD42052524F1E000BC8970 /* SEGWebhookIntegration.h in Headers */,
 				A352176023AD5825005B07F6 /* SEGMacros.h in Headers */,
 				EADEB8D21DECD12B005322DA /* SEGUserDefaultsStorage.h in Headers */,
 				EADEB8D01DECD12B005322DA /* SEGStoreKitTracker.h in Headers */,
@@ -461,6 +468,7 @@
 				TargetAttributes = {
 					EADEB85A1DECD080005322DA = {
 						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 1200;
 						ProvisioningStyle = Manual;
 					};
 					EADEB8691DECD0EF005322DA = {
@@ -519,6 +527,7 @@
 				EADEB8C01DECD12B005322DA /* SEGTrackPayload.m in Sources */,
 				EADEB8AF1DECD12B005322DA /* SEGAES256Crypto.m in Sources */,
 				EADEB8C81DECD12B005322DA /* SEGHTTPClient.m in Sources */,
+				75FD4202252401B500BC8970 /* SEGWebhookIntegration.m in Sources */,
 				EADEB8CC1DECD12B005322DA /* SEGSegmentIntegration.m in Sources */,
 				EADEB8B21DECD12B005322DA /* SEGAliasPayload.m in Sources */,
 				EADEB8BA1DECD12B005322DA /* SEGIntegrationsManager.m in Sources */,
@@ -697,6 +706,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
@@ -715,6 +725,8 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -724,6 +736,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
@@ -742,6 +755,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -750,6 +764,7 @@
 		EADEB8721DECD0EF005322DA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = SegmentTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.segment.AnalyticsTests;
@@ -766,6 +781,7 @@
 		EADEB8731DECD0EF005322DA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = SegmentTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.segment.AnalyticsTests;

--- a/Segment/Classes/SEGWebhookIntegration.h
+++ b/Segment/Classes/SEGWebhookIntegration.h
@@ -1,0 +1,13 @@
+#import "SEGIntegration.h"
+#import "SEGIntegrationFactory.h"
+#import "SEGHTTPClient.h"
+
+NS_SWIFT_NAME(WebhookIntegrationFactory)
+@interface SEGWebhookIntegrationFactory : NSObject <SEGIntegrationFactory>
+
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSString *webhookUrl;
+
+- (instancetype)initWithName:(NSString *)name webhookUrl:(NSString *)webhookUrl;
+
+@end

--- a/Segment/Classes/SEGWebhookIntegration.h
+++ b/Segment/Classes/SEGWebhookIntegration.h
@@ -2,12 +2,15 @@
 #import "SEGIntegrationFactory.h"
 #import "SEGHTTPClient.h"
 
+NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(WebhookIntegrationFactory)
 @interface SEGWebhookIntegrationFactory : NSObject <SEGIntegrationFactory>
 
-@property(nonatomic, copy) NSString *name;
-@property(nonatomic, copy) NSString *webhookUrl;
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *webhookUrl;
 
 - (instancetype)initWithName:(NSString *)name webhookUrl:(NSString *)webhookUrl;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Segment/Classes/SEGWebhookIntegration.m
+++ b/Segment/Classes/SEGWebhookIntegration.m
@@ -1,0 +1,208 @@
+#import <Foundation/Foundation.h>
+#import "SEGWebhookIntegration.h"
+#import "SEGHTTPClient.h"
+#import "SEGState.h"
+#import "SEGAnalyticsUtils.h"
+#import "SEGUtils.h"
+
+
+@interface SEGWebhookIntegration : NSObject <SEGIntegration>
+@property(nonatomic, strong) SEGHTTPClient *client;
+@property(nonatomic, strong) NSString *webhookUrl;
+@property(nonatomic, strong) NSString *name;
+@property(nonatomic, strong) SEGAnalytics *analytics;
+@property (nonatomic, strong) dispatch_queue_t serialQueue;
+
+- (instancetype)initWithAnalytics:(SEGAnalytics *)analytics httpClient:(SEGHTTPClient *)client webhookUrl:(NSString *)webhookUrl name:(NSString *)name;
+@end
+
+@implementation SEGWebhookIntegration
+
+- (instancetype)initWithAnalytics:(SEGAnalytics *)analytics httpClient:(SEGHTTPClient *)client webhookUrl:(NSString *)webhookUrl name:(NSString *)name {
+    if (self = [super init]) {
+        _name = name;
+        _analytics = analytics;
+        _client = client;
+        _webhookUrl = webhookUrl;
+        _serialQueue = seg_dispatch_queue_create_specific("io.segment.analytics.webhook", DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
+- (void)sendPayloadToWebhook:(NSDictionary *)data {
+    NSURLSession *session = self.client.genericSession;
+
+    NSURL *url = [NSURL URLWithString:self.webhookUrl];
+    NSMutableURLRequest *request = self.client.requestFactory(url);
+
+    // This is a workaround for an IOS 8.3 bug that causes Content-Type to be incorrectly set
+    [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+
+    [request setHTTPMethod:@"POST"];
+
+    NSError *error = nil;
+    NSException *exception = nil;
+    NSData *payload = nil;
+    @try {
+        payload = [NSJSONSerialization dataWithJSONObject:data options:0 error:&error];
+    }
+    @catch (NSException *exc) {
+        exception = exc;
+    }
+    if (error || exception) {
+        SEGLog(@"Error serializing JSON for upload to webhook %@", error);
+        return;
+    }
+
+    NSURLSessionUploadTask *task = [session uploadTaskWithRequest:request fromData:payload completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response, NSError *_Nullable error) {
+        if (error) {
+            // Network error. Retry.
+            SEGLog(@"Error uploading request %@.", error);
+            return;
+        }
+
+        NSInteger code = ((NSHTTPURLResponse *)response).statusCode;
+        if (code < 300) {
+            // 2xx response codes. Don't retry.
+            return;
+        }
+        if (code < 400) {
+            // 3xx response codes. Retry.
+            SEGLog(@"Server responded with unexpected HTTP code %d.", code);
+            return;
+        }
+        if (code == 429) {
+            // 429 response codes. Retry.
+            SEGLog(@"Server limited client with response code %d.", code);
+            return;
+        }
+        if (code < 500) {
+            // non-429 4xx response codes. Don't retry.
+            SEGLog(@"Server rejected payload with HTTP code %d.", code);
+            return;
+        }
+
+        // 5xx response codes. Retry.
+        SEGLog(@"Server error with HTTP code %d.", code);
+    }];
+    [task resume];
+}
+
+// Merges user provided integration options with bundled integrations.
+- (NSDictionary *)integrationsDictionary:(NSDictionary *)integrations
+{
+    NSMutableDictionary *dict = [integrations ?: @{} mutableCopy];
+    for (NSString *integration in self.analytics.bundledIntegrations) {
+        // Don't record Segment.io in the dictionary. It is always enabled.
+        if ([integration isEqualToString:@"Segment.io"]) {
+            continue;
+        }
+        dict[integration] = @NO;
+    }
+    return [dict copy];
+}
+
+// Code borrowed from SEGSegmentIntegration.enqueueAction
+- (void)enqueue:(NSString *) type dictionary:(NSMutableDictionary *) payload context:(NSDictionary *)context integrations:(NSDictionary *)integrations
+{
+    payload[@"type"] = type;
+    if (![type isEqualToString:@"alias"]) {
+        [payload setValue:[SEGState sharedInstance].userInfo.userId forKey:@"userId"];
+    }
+    [payload setValue:[self.analytics getAnonymousId] forKey:@"anonymousId"];
+    [payload setValue:[self integrationsDictionary:integrations] forKey:@"integrations"];
+    [payload setValue:[context copy] forKey:@"context"];
+
+    [self dispatchBackground:^{
+        SEGLog(@"%@ Enqueueing payload %@ through %@", self, type, self.name);
+        NSDictionary *queuePayload = [payload copy];
+        [self sendPayloadToWebhook:queuePayload];
+    }];
+}
+
+- (void)dispatchBackground:(void (^)(void))block
+{
+    seg_dispatch_specific_async(_serialQueue, block);
+}
+
+- (NSString *)userId
+{
+    return [SEGState sharedInstance].userInfo.userId;
+}
+
+- (void)identify:(SEGIdentifyPayload *)payload
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    [dictionary setValue:payload.traits forKey:@"traits"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
+    [dictionary setValue:payload.messageId forKey:@"messageId"];
+
+    [self enqueue:@"identify" dictionary:dictionary context:payload.context integrations:payload.integrations];
+}
+
+- (void)track:(SEGTrackPayload *)payload
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    [dictionary setValue:payload.event forKey:@"event"];
+    [dictionary setValue:payload.properties forKey:@"properties"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
+    [dictionary setValue:payload.messageId forKey:@"messageId"];
+
+    [self enqueue:@"track" dictionary:dictionary context:payload.context integrations:payload.integrations];
+}
+
+- (void)screen:(SEGScreenPayload *)payload
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    [dictionary setValue:payload.name forKey:@"name"];
+    [dictionary setValue:payload.properties forKey:@"properties"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
+    [dictionary setValue:payload.messageId forKey:@"messageId"];
+
+    [self enqueue:@"screen" dictionary:dictionary context:payload.context integrations:payload.integrations];
+}
+
+- (void)group:(SEGGroupPayload *)payload
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    [dictionary setValue:payload.groupId forKey:@"groupId"];
+    [dictionary setValue:payload.traits forKey:@"traits"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
+    [dictionary setValue:payload.messageId forKey:@"messageId"];
+
+    [self enqueue:@"group" dictionary:dictionary context:payload.context integrations:payload.integrations];
+}
+
+- (void)alias:(SEGAliasPayload *)payload
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    [dictionary setValue:payload.theNewId forKey:@"userId"];
+    [dictionary setValue:self.userId ?: [self.analytics getAnonymousId] forKey:@"previousId"];
+    [dictionary setValue:payload.timestamp forKey:@"timestamp"];
+    [dictionary setValue:payload.messageId forKey:@"messageId"];
+
+    [self enqueue:@"alias" dictionary:dictionary context:payload.context integrations:payload.integrations];
+}
+
+@end
+
+@implementation SEGWebhookIntegrationFactory
+- (instancetype)initWithName:(NSString *)name webhookUrl:(NSString *)webhookUrl {
+    if (self = [super init]) {
+        _name = name;
+        _webhookUrl = webhookUrl;
+    }
+    return self;
+}
+
+- (id <SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics {
+    SEGHTTPClient *httpClient = [[SEGHTTPClient alloc] initWithRequestFactory:nil];
+    return [[SEGWebhookIntegration alloc] initWithAnalytics:analytics httpClient:httpClient webhookUrl:self.webhookUrl name:self.name];
+}
+
+- (NSString *)key {
+    return [NSString stringWithFormat:@"webhook_%@", _name];
+}
+
+
+@end

--- a/Segment/Classes/SEGWebhookIntegration.m
+++ b/Segment/Classes/SEGWebhookIntegration.m
@@ -5,16 +5,20 @@
 #import "SEGAnalyticsUtils.h"
 #import "SEGUtils.h"
 
-
+NS_ASSUME_NONNULL_BEGIN
 @interface SEGWebhookIntegration : NSObject <SEGIntegration>
-@property(nonatomic, strong) SEGHTTPClient *client;
-@property(nonatomic, strong) NSString *webhookUrl;
-@property(nonatomic, strong) NSString *name;
-@property(nonatomic, strong) SEGAnalytics *analytics;
+
+@property (nonatomic, strong) SEGHTTPClient *client;
+@property (nonatomic, strong) NSString *webhookUrl;
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) SEGAnalytics *analytics;
 @property (nonatomic, strong) dispatch_queue_t serialQueue;
 
 - (instancetype)initWithAnalytics:(SEGAnalytics *)analytics httpClient:(SEGHTTPClient *)client webhookUrl:(NSString *)webhookUrl name:(NSString *)name;
+
 @end
+
+NS_ASSUME_NONNULL_END
 
 @implementation SEGWebhookIntegration
 
@@ -68,22 +72,22 @@
         }
         if (code < 400) {
             // 3xx response codes. Retry.
-            SEGLog(@"Server responded with unexpected HTTP code %d.", code);
+            SEGLog(@"Server responded with unexpected HTTP code %zd.", code);
             return;
         }
         if (code == 429) {
             // 429 response codes. Retry.
-            SEGLog(@"Server limited client with response code %d.", code);
+            SEGLog(@"Server limited client with response code %zd.", code);
             return;
         }
         if (code < 500) {
             // non-429 4xx response codes. Don't retry.
-            SEGLog(@"Server rejected payload with HTTP code %d.", code);
+            SEGLog(@"Server rejected payload with HTTP code %zd.", code);
             return;
         }
 
         // 5xx response codes. Retry.
-        SEGLog(@"Server error with HTTP code %d.", code);
+        SEGLog(@"Server error with HTTP code %zd.", code);
     }];
     [task resume];
 }

--- a/Segment/Classes/Segment.h
+++ b/Segment/Classes/Segment.h
@@ -21,3 +21,4 @@ FOUNDATION_EXPORT const unsigned char SegmentVersionString[];
 #import "SEGMiddleware.h"
 #import "SEGScreenReporting.h"
 #import "SEGAnalyticsUtils.h"
+#import "SEGWebhookIntegration.h"

--- a/Segment/Internal/SEGIntegrationsManager.m
+++ b/Segment/Internal/SEGIntegrationsManager.m
@@ -413,7 +413,7 @@ NSString *const kSEGCachedSettingsFilename = @"analytics.settings.v2.plist";
             if (isUnitTesting()) {
                 integrationSettings = @{};
             }
-            if (integrationSettings) {
+            if (integrationSettings || [key hasPrefix:@"webhook_"]) {
                 id<SEGIntegration> integration = [factory createWithSettings:integrationSettings forAnalytics:self.analytics];
                 if (integration != nil) {
                     self.integrations[key] = integration;


### PR DESCRIPTION
**What does this PR do?**
This change adds a webhook device-mode destination. This is being added solely for debugging/observability purposes but can used for other use cases as well.

**Where should the reviewer start?**
SEGWebhookIntegration.m

**How should this be manually tested?**
use the new WebhookIntegrationFactory integration with a valid webhook url (can retrieve one from [webhook.site](https://webhook.site/)), and proceed to send events. The webhook should receive events if correctly configured.
Code:
```swift
let configuration = AnalyticsConfiguration(writeKey: WRITE_KEY)
let webhookDestination : SEGIntegrationFactory = WebhookIntegrationFactory.init(name: "dest1", webhookUrl: "<webhookURL>")
configuration.use(webhookDestination)
```

**What are the relevant tickets?**

**Questions:**
- Does the docs need an update? Maybe
- Are there any security concerns? Nope
- Do we need to update engineering / success? Yes
