### PR TITLE
Fix configuration setting for edgefn

### DIFF
--- a/Segment/Classes/SEGAnalytics.m
+++ b/Segment/Classes/SEGAnalytics.m
@@ -52,11 +52,6 @@ static SEGAnalytics *__sharedInstance = nil;
         // TODO: Figure out if this is really the best way to do things here.
         self.integrationsManager = [[SEGIntegrationsManager alloc] initWithAnalytics:self];
         
-        if (configuration.edgeFunctionMiddleware) {
-            configuration.sourceMiddleware = @[[configuration.edgeFunctionMiddleware sourceMiddleware]];
-            configuration.destinationMiddleware = @[[configuration.edgeFunctionMiddleware destinationMiddleware]];
-        }
-
         self.runner = [[SEGMiddlewareRunner alloc] initWithMiddleware:
                                                        [configuration.sourceMiddleware ?: @[] arrayByAddingObject:self.integrationsManager]];
 

--- a/Segment/Classes/SEGAnalyticsConfiguration.m
+++ b/Segment/Classes/SEGAnalyticsConfiguration.m
@@ -8,6 +8,7 @@
 
 #import "SEGAnalyticsConfiguration.h"
 #import "SEGAnalytics.h"
+#import "SEGMiddleware.h"
 #import "SEGCrypto.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -105,6 +106,12 @@
 - (NSArray<id<SEGMiddleware>> *)middlewares
 {
     return self.sourceMiddleware;
+}
+
+- (void)setEdgeFunctionMiddleware:(id<SEGEdgeFunctionMiddleware>)edgeFunctionMiddleware
+{
+    self.sourceMiddleware = edgeFunctionMiddleware.sourceMiddleware;
+    self.destinationMiddleware = edgeFunctionMiddleware.destinationMiddleware;
 }
 
 @end


### PR DESCRIPTION
- Removes configuration shimmy from SEGAnalytics and puts it in SEGAnalyticsConfiguration where it belongs.
- Stops trying to double wrap options in array.