### PR TITLE
Fix "Application Opened" event when app starts by deeplink

### DIFF
--- a/Segment/Classes/SEGAnalytics.m
+++ b/Segment/Classes/SEGAnalytics.m
@@ -197,7 +197,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
         @"version" : currentVersion ?: @"",
         @"build" : currentBuild ?: @"",
         @"referring_application" : launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: @"",
-        @"url" : launchOptions[UIApplicationLaunchOptionsURLKey] ?: @"",
+        @"url" : [launchOptions[UIApplicationLaunchOptionsURLKey] absoluteString] ?: @"",
     }];
 #elif TARGET_OS_OSX
     [self track:@"Application Opened" properties:@{

--- a/SegmentTests/AnalyticsTests.swift
+++ b/SegmentTests/AnalyticsTests.swift
@@ -168,17 +168,17 @@ class AnalyticsTests: XCTestCase {
     #if os(iOS)
     func testFiresApplicationOpenedForAppLaunchingEvent() {
         testMiddleware.swallowEvent = true
+        let url = URL(string: "test://url")!
         NotificationCenter.default.post(name: UIApplication.didFinishLaunchingNotification, object: testApplication, userInfo: [
             UIApplication.LaunchOptionsKey.sourceApplication: "testApp",
-            UIApplication.LaunchOptionsKey.url: "test://test",
+            UIApplication.LaunchOptionsKey.url: url,
         ])
         let event = testMiddleware.lastContext?.payload as? TrackPayload
         XCTAssertEqual(event?.event, "Application Opened")
         XCTAssertEqual(event?.properties?["from_background"] as? Bool, false)
         XCTAssertEqual(event?.properties?["referring_application"] as? String, "testApp")
-        XCTAssertEqual(event?.properties?["url"] as? String, "test://test")
+        XCTAssertEqual(event?.properties?["url"] as? String, url.absoluteString)
     }
-    #else
     #endif
     
     func testFiresApplicationEnterForeground() {


### PR DESCRIPTION
**What does this PR do?**
- Fixes assertion failures in Debug build when app starts by deeplink.
- Fixes missing "url" parameter in "Application Opened" tracking event

**How should this be manually tested?**
- Change app scheme to "Wait for the executable to be launched"
- Start app by deeplink
- Ensure app didn't crashed (without debugger) or stopped on assertion in SEGUtils.m file
- Check with Segment Debugger that "Application Opened" tracking event contains "url" parameter

**Any background context you want to provide?**
https://developer.apple.com/documentation/uikit/uiapplicationlaunchoptionsurlkey?language=objc

**What are the relevant tickets?**
#947

**Questions:**
- Does the docs need an update?
  No.
- Are there any security concerns?
  Most likely not as PR contains just fixes.
- Do we need to update engineering / success?
  Maybe? _That question is unclear and need to be rephrased_
