### PR TITLE
Added category option to screen calls

### DIFF
--- a/Segment/Classes/SEGAnalytics.h
+++ b/Segment/Classes/SEGAnalytics.h
@@ -107,9 +107,13 @@ NS_SWIFT_NAME(Analytics)
  When a user views a screen in your app, you'll want to record that here. For some tools like Google Analytics and Flurry, screen views are treated specially, and are different from "events" kind of like "page views" on the web. For services that don't treat "screen views" specially, we map "screen" straight to "track" with the same parameters. For example, Mixpanel doesn't treat "screen views" any differently. So a call to "screen" will be tracked as a normal event in Mixpanel, but get sent to Google Analytics and Flurry as a "screen".
 
  */
+- (void)screen:(NSString *)screenTitle category:(NSString * _Nullable)category properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
 - (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
+- (void)screen:(NSString *)screenTitle category:(NSString * _Nullable)category properties:(SERIALIZABLE_DICT _Nullable)properties;
 - (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties;
+- (void)screen:(NSString *)screenTitle category:(NSString * _Nullable)category;
 - (void)screen:(NSString *)screenTitle;
+
 
 /*!
  @method

--- a/Segment/Classes/SEGAnalytics.m
+++ b/Segment/Classes/SEGAnalytics.m
@@ -328,20 +328,36 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
 - (void)screen:(NSString *)screenTitle
 {
-    [self screen:screenTitle properties:nil options:nil];
+    [self screen:screenTitle category:nil properties:nil options:nil];
+}
+
+- (void)screen:(NSString *)screenTitle category:(NSString *)category
+{
+    [self screen:screenTitle category:category properties:nil options:nil];
 }
 
 - (void)screen:(NSString *)screenTitle properties:(NSDictionary *)properties
 {
-    [self screen:screenTitle properties:properties options:nil];
+    [self screen:screenTitle category:nil properties:properties options:nil];
+}
+
+- (void)screen:(NSString *)screenTitle category:(NSString *)category properties:(SERIALIZABLE_DICT _Nullable)properties
+{
+    [self screen:screenTitle category:category properties:properties options:nil];
 }
 
 - (void)screen:(NSString *)screenTitle properties:(NSDictionary *)properties options:(NSDictionary *)options
+{
+    [self screen:screenTitle category:nil properties:properties options:options];
+}
+
+- (void)screen:(NSString *)screenTitle category:(NSString *)category properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options
 {
     NSCAssert1(screenTitle.length > 0, @"screen name (%@) must not be empty.", screenTitle);
 
     [self run:SEGEventTypeScreen payload:
                                      [[SEGScreenPayload alloc] initWithName:screenTitle
+                                                                   category:category
                                                                  properties:SEGCoerceDictionary(properties)
                                                                     context:SEGCoerceDictionary([options objectForKey:@"context"])
                                                                integrations:[options objectForKey:@"integrations"]]];

--- a/Segment/Classes/SEGScreenPayload.h
+++ b/Segment/Classes/SEGScreenPayload.h
@@ -14,6 +14,7 @@ NS_SWIFT_NAME(ScreenPayload)
 @property (nonatomic, readonly, nullable) NSDictionary *properties;
 
 - (instancetype)initWithName:(NSString *)name
+                    category:(NSString *)category
                   properties:(NSDictionary *_Nullable)properties
                      context:(NSDictionary *)context
                 integrations:(NSDictionary *)integrations;

--- a/Segment/Classes/SEGScreenPayload.m
+++ b/Segment/Classes/SEGScreenPayload.m
@@ -4,12 +4,14 @@
 @implementation SEGScreenPayload
 
 - (instancetype)initWithName:(NSString *)name
+                    category:(NSString *)category
                   properties:(NSDictionary *)properties
                      context:(NSDictionary *)context
                 integrations:(NSDictionary *)integrations
 {
     if (self = [super initWithContext:context integrations:integrations]) {
         _name = [name copy];
+        _category = [category copy];
         _properties = [properties copy];
     }
     return self;

--- a/SegmentTests/TrackingTests.swift
+++ b/SegmentTests/TrackingTests.swift
@@ -78,12 +78,13 @@ class TrackingTests: XCTestCase {
     }
     
     func testHandlesScreen() {
-        analytics.screen("Home", properties: [
+        analytics.screen("Home", category:"test", properties: [
             "referrer": "Google"
         ])
         XCTAssertEqual(passthrough.lastContext?.eventType, EventType.screen)
         let screen = passthrough.lastContext?.payload as? ScreenPayload
         XCTAssertEqual(screen?.name, "Home")
+        XCTAssertEqual(screen?.category, "test")
         XCTAssertEqual(screen?.properties?["referrer"] as? String, "Google")
     }
     


### PR DESCRIPTION
Adds 3 new versions of the screen call to allow category to be passed while maintaining compatibility with previous call points.

```
- (void)screen:(NSString *)screenTitle category:(NSString * _Nullable)category properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
- (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties options:(SERIALIZABLE_DICT _Nullable)options;
- (void)screen:(NSString *)screenTitle category:(NSString * _Nullable)category properties:(SERIALIZABLE_DICT _Nullable)properties;
- (void)screen:(NSString *)screenTitle properties:(SERIALIZABLE_DICT _Nullable)properties;
- (void)screen:(NSString *)screenTitle category:(NSString * _Nullable)category;
- (void)screen:(NSString *)screenTitle;
```
