### PR TITLE
Fixed issue w/ NSCopying being used before SEGSerialization

### DIFF
--- a/Segment/Internal/SEGUtils.m
+++ b/Segment/Internal/SEGUtils.m
@@ -543,10 +543,10 @@ NSString *SEGEventNameForScreenTitle(NSString *title)
         
         if ([aValue conformsToProtocol:@protocol(SEGSerializableDeepCopy)]) {
             theCopy = [aValue serializableDeepCopy:mutable];
-        } else if ([aValue conformsToProtocol:@protocol(NSCopying)]) {
-            theCopy = [aValue copy];
         } else if ([aValue conformsToProtocol:@protocol(SEGSerializable)]) {
             theCopy = [aValue serializeToAppropriateType];
+        } else if ([aValue conformsToProtocol:@protocol(NSCopying)]) {
+            theCopy = [aValue copy];
         } else {
             theCopy = aValue;
         }
@@ -594,10 +594,10 @@ NSString *SEGEventNameForScreenTitle(NSString *title)
 
         if ([aValue conformsToProtocol:@protocol(SEGSerializableDeepCopy)]) {
             theCopy = [aValue serializableDeepCopy:mutable];
-        } else if ([aValue conformsToProtocol:@protocol(NSCopying)]) {
-            theCopy = [aValue copy];
         } else if ([aValue conformsToProtocol:@protocol(SEGSerializable)]) {
             theCopy = [aValue serializeToAppropriateType];
+        } else if ([aValue conformsToProtocol:@protocol(NSCopying)]) {
+            theCopy = [aValue copy];
         } else {
             theCopy = aValue;
         }

--- a/SegmentTests/SerializationTests.m
+++ b/SegmentTests/SerializationTests.m
@@ -98,11 +98,17 @@ JSON_DICT SEGCoerceDictionary(NSDictionary *_Nullable dict);
     XCTAssertThrows([nonserializable serializableDeepCopy]);
     
     NSDictionary *testCoersion1 = @{@"test1": @[date], @"test2": url, @"test3": @1};
-    NSDictionary *coersionResult1 = SEGCoerceDictionary(testCoersion1);
-    XCTAssertNotNil(coersionResult1);
+    NSDictionary *coersionResult = SEGCoerceDictionary(testCoersion1);
+    XCTAssertNotNil(coersionResult);
     
     NSDictionary *testCoersion2 = @{@"test1": @[date], @"test2": url, @"test3": @1, @"test4": data};
     XCTAssertThrows(SEGCoerceDictionary(testCoersion2));
+    
+    NSError *error = nil;
+    NSData *json = [NSJSONSerialization dataWithJSONObject:coersionResult options:NSJSONWritingPrettyPrinted error:&error];
+    
+    XCTAssertNil(error);
+    XCTAssertNotNil(json);
 }
 
 @end


### PR DESCRIPTION
- Fixes issue with NSCopying conformance being checked before SEGSerialization causing non-serializable items to make it through.
- Addresses #959, #947, and PR #954 