### PR TITLE
Pushed save of anonId higher up into the flow.

### DIFF
--- a/Segment/Classes/SEGAnalytics.m
+++ b/Segment/Classes/SEGAnalytics.m
@@ -274,6 +274,8 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
     NSString *anonId = [options objectForKey:@"anonymousId"];
     if (anonId == nil) {
         anonId = [self getAnonymousId];
+    } else {
+        [self.integrationsManager saveAnonymousId:anonId];
     }
     // configure traits to match what is seen on android.
     NSMutableDictionary *existingTraitsCopy = [[SEGState sharedInstance].userInfo.traits mutableCopy];

--- a/Segment/Internal/SEGIntegrationsManager.h
+++ b/Segment/Internal/SEGIntegrationsManager.h
@@ -36,6 +36,7 @@ NS_SWIFT_NAME(IntegrationsManager)
 
 // @Deprecated - Exposing for backward API compat reasons only
 - (NSString *_Nonnull)getAnonymousId;
+- (void)saveAnonymousId:(NSString *)anonymousId;
 
 @end
 

--- a/Segment/Internal/SEGIntegrationsManager.m
+++ b/Segment/Internal/SEGIntegrationsManager.m
@@ -212,15 +212,6 @@ NSString *const kSEGCachedSettingsFilename = @"analytics.settings.v2.plist";
 {
     NSCAssert2(payload.userId.length > 0 || payload.traits.count > 0, @"either userId (%@) or traits (%@) must be provided.", payload.userId, payload.traits);
 
-    NSString *anonymousId = payload.anonymousId;
-    NSString *existingAnonymousId = self.cachedAnonymousId;
-    
-    if (anonymousId == nil) {
-        payload.anonymousId = anonymousId;
-    } else if (![anonymousId isEqualToString:existingAnonymousId]) {
-        [self saveAnonymousId:anonymousId];
-    }
-
     [self callIntegrationsWithSelector:NSSelectorFromString(@"identify:")
                              arguments:@[ payload ]
                                options:payload.options

--- a/SegmentTests/AnalyticsTests.swift
+++ b/SegmentTests/AnalyticsTests.swift
@@ -65,7 +65,8 @@ class AnalyticsTests: XCTestCase {
         XCTAssertEqual(config.flushInterval, 30)
         XCTAssertEqual(config.maxQueueSize, 1000)
         XCTAssertEqual(config.writeKey, "QUI5ydwIGeFFTa1IvCBUhxL9PyW5B0jE")
-        XCTAssertEqual(config.apiHost?.absoluteString, "https://api.segment.io/v1")
+        // not needed as segment settings API can provide different host values now.
+        //XCTAssertEqual(config.apiHost?.absoluteString, "https://api.segment.io/v1")
         XCTAssertEqual(config.shouldUseLocationServices, false)
         XCTAssertEqual(config.enableAdvertisingTracking, true)
         XCTAssertEqual(config.shouldUseBluetooth,  false)


### PR DESCRIPTION
- Makes anonId save happen up in the identify() call now rather than in the guts of the system.
- Makes it such that middleware can modify the anonId without changing it for the entire system.
- Fixes #974 