### PR TITLE
Fix the build of the Swift Package with Xcode 12.5 beta 1

### DIFF
--- a/Segment/Internal/SEGIntegrationsManager.m
+++ b/Segment/Internal/SEGIntegrationsManager.m
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Segment. All rights reserved.
 //
 
+@import Foundation;
 #if TARGET_OS_IPHONE
 @import UIKit;
 #endif


### PR DESCRIPTION
**What does this PR do?**

Fix a build failure with the newly released Xcode 12.5 beta 1

**Where should the reviewer start?**

Try to build the Swift Package with Xcode 12.5 beta 1

**How should this be manually tested?**

Build.

**Any background context you want to provide?**

Xcode 12.5 beta 1 was released today, and introduces a new error when a `#if` statement is used with an undefined variable: "error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0". This affects a single file, `SEGIntegrationsManager.m`.

**Questions:**
- Does the docs need an update?
No.
- Are there any security concerns?
No.
- Do we need to update engineering / success?
No.