### PR TITLE
Remove SwiftName/SwiftUI conflict

### DIFF
--- a/Segment/Classes/SEGContext.h
+++ b/Segment/Classes/SEGContext.h
@@ -48,7 +48,6 @@ typedef NS_ENUM(NSInteger, SEGEventType) {
 @protocol SEGMutableContext;
 
 
-NS_SWIFT_NAME(Context)
 @interface SEGContext : NSObject <NSCopying>
 
 // Loopback reference to the top level SEGAnalytics object.

--- a/SegmentTests/ContextTest.swift
+++ b/SegmentTests/ContextTest.swift
@@ -24,7 +24,7 @@ class ContextTests: XCTestCase {
         var exception: NSException?
         
         exception = objc_tryCatch {
-            context = Context()
+            context = SEGContext()
         }
         
         XCTAssertNil(context)
@@ -32,13 +32,13 @@ class ContextTests: XCTestCase {
     }
     
     func testInitializedCorrectly() {
-        let context = Context(analytics: analytics)
+        let context = SEGContext(analytics: analytics)
         XCTAssertEqual(context._analytics, analytics)
         XCTAssertEqual(context.eventType, EventType.undefined)
     }
     
     func testAcceptsModifications() {
-        let context = Context(analytics: analytics)
+        let context = SEGContext(analytics: analytics)
         
         let newContext = context.modify { context in
             context.payload = TrackPayload()
@@ -50,7 +50,7 @@ class ContextTests: XCTestCase {
     }
     
     func testModifiesCopyInDebugMode() {
-        let context = Context(analytics: analytics).modify { context in
+        let context = SEGContext(analytics: analytics).modify { context in
             context.debug = true
             context.eventType = .track
         }
@@ -65,7 +65,7 @@ class ContextTests: XCTestCase {
     }
     
     func testModifiesSelfInNonDebug() {
-        let context = Context(analytics: analytics).modify { context in
+        let context = SEGContext(analytics: analytics).modify { context in
             context.debug = false
             context.eventType = .track
         }


### PR DESCRIPTION
Problem:
Segment Context Swift Name is conflicting with SwiftUI UIViewRepresentable

resolves https://github.com/segmentio/analytics-ios/issues/975

**What does this PR do?**

When using Segment + SwiftUI, there is a namespace collision between SegContext (using swift name Context) and SwiftUI Context, which isn't a part of SwiftUI namespace leading to a collision.

**Where should the reviewer start?**

**How should this be manually tested?**

Attempt to integration with SwiftUI project that uses UIViewRepresentable/UIViewController Representable

example:
If using existing Segment branch, Context will conflict with Segment Context and fail to compile
```
import AuthenticationServices
import SwiftUI

final class SignInWithApple: UIViewRepresentable {

    func makeUIView(context: Context) -> ASAuthorizationAppleIDButton {
        // 3
        return ASAuthorizationAppleIDButton()
    }

    // 4
    func updateUIView(_ uiView: ASAuthorizationAppleIDButton, context: Context) {}
}
```

**Any background context you want to provide?**

**What are the relevant tickets?**

https://github.com/segmentio/analytics-ios/issues/975

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
- Are there any security concerns?
- Do we need to update engineering / success?
