### PR TITLE
Fix new warning in Xcode 12.5 Beta 2 (12E5234g): "Cast to smaller integer type 'unsigned int' from 'SEGReachability *'".

### DIFF
--- a/Segment/Classes/SEGReachability.m
+++ b/Segment/Classes/SEGReachability.m
@@ -489,10 +489,10 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 #pragma mark - Debug Description
 
-- (NSString *)description;
+- (NSString *) description
 {
-    NSString *description = [NSString stringWithFormat:@"<%@: %#x>",
-                                                       NSStringFromClass([self class]), (unsigned int)self];
+    NSString *description = [NSString stringWithFormat:@"<%@: %p (%@)>",
+                             NSStringFromClass([self class]), self, [self currentReachabilityFlags]];
     return description;
 }
 


### PR DESCRIPTION
Code copied for this specific function (currently unused) from https://github.com/tonymillion/Reachability/blob/ea5dd8d4646ecb2f0d07e6619827df1dfea809b8/Reachability.m#L501

**What does this PR do?**

Fixes warning in Xcode 12.5 Beta 2 (12E5234g).
Change is backward compatible with Xcode 12.4 and likely earlier Xcode versions.

**Where should the reviewer start?**

Build existing codebase in Xcode 12.5 Beta 2 to observe warning.

**How should this be manually tested?**

The description function is not actually used, and is only included by virtue of being copied from the Reachability project. In any case, I manually tested by calling `description` after the SEGReachability instance was initialized like so:

`self.reachability = [SEGReachability reachabilityWithHostname:@"google.com"];`
`NSLog(self.reachability.description);`

**Any background context you want to provide?**

Someone may want to consider refreshing all of Reachability, but this felt like too big of a change.

**What are the relevant tickets?**

Don't see open issue for this.

**Screenshots or screencasts (if UI/UX change)**

Not applicable.

**Questions:**
- Does the docs need an update? No
- Are there any security concerns? I don't believe so
- Do we need to update engineering / success? Not sure?
