### PR TITLE
Fix deadlock on first app launch

### DIFF
--- a/Segment/Internal/SEGIntegrationsManager.m
+++ b/Segment/Internal/SEGIntegrationsManager.m
@@ -156,7 +156,9 @@ NSString *const kSEGCachedSettingsFilename = @"analytics.settings.v2.plist";
 
 - (void)onAppForeground:(NSNotification *)note
 {
-    [self refreshSettings];
+    seg_dispatch_specific_async(_serialQueue, ^{
+        [self refreshSettings];
+    });
 }
 
 - (void)handleAppStateNotification:(NSString *)notificationName


### PR DESCRIPTION
**What does this PR do?**
Fixes #1008

**Where should the reviewer start?**
`Segment/Internal/SEGIntegrationsManager.m`
it is small change

**How should this be manually tested?**
Requirements:
- App integrating segment SDK
- Fresh install of an app
- Amplitude integration configured
- Luck

This is race condition so it happens infrequently. To emulate problematic condition failing always before and not failing after the fix add `[NSThread sleepForTimeInterval:3];` inside `-[SEGIntegrationsManager setCachedSettings:]` line before `[self updateIntegrationsWithSettings:settings[@"integrations"]];`

**Any background context you want to provide?**
See #1008

**What are the relevant tickets?**
#1008

**Screenshots or screencasts (if UI/UX change)**
not UI/UX change

**Questions:**
- Does the docs need an update?
  - No.
- Are there any security concerns?
  - No.
- Do we need to update engineering / success?
  - I don't think so.