### PR TITLE
Removed unused exclude in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,6 @@ let package = Package(
             name: "Segment",
             dependencies: [],
             path: "Segment/",
-            exclude: ["SwiftSources"],
             sources: ["Classes", "Internal"],
             publicHeadersPath: "Classes",
             cSettings: [


### PR DESCRIPTION
Removed unused exclude in Package.swift which generates a warning in Xcode 13.

Closes #1015