### PR TITLE
Relays upload request errors via nsnotifications

### DIFF
--- a/Segment/Classes/SEGHTTPClient.h
+++ b/Segment/Classes/SEGHTTPClient.h
@@ -27,7 +27,7 @@ NS_SWIFT_NAME(HTTPClient)
  * NOTE: You need to re-dispatch within the completionHandler onto a desired queue to avoid threading issues.
  * Completion handlers are called on a dispatch queue internal to SEGHTTPClient. 
  */
-- (nullable NSURLSessionUploadTask *)upload:(JSON_DICT)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler;
+- (nullable NSURLSessionUploadTask *)upload:(JSON_DICT)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry, NSError * _Nullable error))completionHandler;
 
 - (NSURLSessionDataTask *)settingsForWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL success, JSON_DICT _Nullable settings))completionHandler;
 

--- a/Segment/Classes/SEGHTTPClient.m
+++ b/Segment/Classes/SEGHTTPClient.m
@@ -5,6 +5,13 @@
 
 #define SEGMENT_CDN_BASE [NSURL URLWithString:@"https://cdn-settings.segment.com/v1"]
 
+NSString * const kSegmentHttpClientErrorDomain = @"com.segment.httpclient";
+
+typedef NS_ENUM(NSInteger, SegHttpClientError) {
+    SegHttpClientErrorBatchSizeLimit = 1000,
+    SegHttpClientErrorRequest
+};
+
 static const NSUInteger kMaxBatchSize = 475000; // 475KB
 
 NSString * const kSegmentAPIBaseHost = @"https://api.segment.io/v1";
@@ -72,7 +79,7 @@ NSString * const kSegmentAPIBaseHost = @"https://api.segment.io/v1";
 }
 
 
-- (nullable NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry))completionHandler
+- (nullable NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry, NSError * _Nullable error))completionHandler
 {
     //    batch = SEGCoerceDictionary(batch);
     NSURLSession *session = [self sessionForWriteKey:writeKey];
@@ -96,12 +103,12 @@ NSString * const kSegmentAPIBaseHost = @"https://api.segment.io/v1";
     }
     if (error || exception) {
         SEGLog(@"Error serializing JSON for batch upload %@", error);
-        completionHandler(NO); // Don't retry this batch.
+        completionHandler(NO, error); // Don't retry this batch.
         return nil;
     }
     if (payload.length >= kMaxBatchSize) {
         SEGLog(@"Payload exceeded the limit of %luKB per batch", kMaxBatchSize / 1000);
-        completionHandler(NO);
+        completionHandler(NO, [NSError errorWithDomain: kSegmentHttpClientErrorDomain code: SegHttpClientErrorBatchSizeLimit userInfo: nil]);
         return nil;
     }
     NSData *gzippedPayload = [payload seg_gzippedData];
@@ -110,38 +117,45 @@ NSString * const kSegmentAPIBaseHost = @"https://api.segment.io/v1";
         if (error) {
             // Network error. Retry.
             SEGLog(@"Error uploading request %@.", error);
-            completionHandler(YES);
+            completionHandler(YES, error);
             return;
         }
 
         NSInteger code = ((NSHTTPURLResponse *)response).statusCode;
+        
+        NSDictionary *userInfo = @{
+            NSLocalizedDescriptionKey:NSLocalizedString(@"Server responded with unexpected HTTP code %d.", @(code).stringValue)
+        };
+        
+        NSError *responseError = [NSError errorWithDomain:kSegmentHttpClientErrorDomain code:SegHttpClientErrorRequest userInfo:userInfo];
+
         if (code < 300) {
             // 2xx response codes. Don't retry.
-            completionHandler(NO);
+            completionHandler(NO, nil);
             return;
         }
         if (code < 400) {
             // 3xx response codes. Retry.
             SEGLog(@"Server responded with unexpected HTTP code %d.", code);
-            completionHandler(YES);
+            completionHandler(YES, responseError);
             return;
         }
         if (code == 429) {
           // 429 response codes. Retry.
           SEGLog(@"Server limited client with response code %d.", code);
-          completionHandler(YES);
+          completionHandler(YES, responseError);
           return;
         }
         if (code < 500) {
             // non-429 4xx response codes. Don't retry.
             SEGLog(@"Server rejected payload with HTTP code %d.", code);
-            completionHandler(NO);
+            completionHandler(NO, responseError);
             return;
         }
 
         // 5xx response codes. Retry.
         SEGLog(@"Server error with HTTP code %d.", code);
-        completionHandler(YES);
+        completionHandler(YES, responseError);
     }];
     [task resume];
     return task;

--- a/Segment/Classes/SEGSegmentIntegration.m
+++ b/Segment/Classes/SEGSegmentIntegration.m
@@ -377,10 +377,10 @@ NSUInteger const kSEGBackgroundTaskInvalid = 0;
     }];
 }
 
-- (void)notifyForName:(NSString *)name userInfo:(id)userInfo
+- (void)notifyForName:(NSString *)name object:(id)object userInfo:(id)userInfo
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:name object:userInfo];
+        [[NSNotificationCenter defaultCenter] postNotificationName:name object:object userInfo:userInfo];
         SEGLog(@"sent notification %@", name);
     });
 }
@@ -394,10 +394,15 @@ NSUInteger const kSEGBackgroundTaskInvalid = 0;
     SEGLog(@"%@ Flushing %lu of %lu queued API calls.", self, (unsigned long)batch.count, (unsigned long)self.queue.count);
     SEGLog(@"Flushing batch %@.", payload);
 
-    self.batchRequest = [self.httpClient upload:payload forWriteKey:self.configuration.writeKey completionHandler:^(BOOL retry) {
+    self.batchRequest = [self.httpClient upload:payload forWriteKey:self.configuration.writeKey completionHandler:^(BOOL retry, NSError *error) {
         void (^completion)(void) = ^{
+            NSDictionary *errorDict;
+            if (error != nil) {
+                errorDict = @{ @"Error":error };
+            }
+
             if (retry) {
-                [self notifyForName:SEGSegmentRequestDidFailNotification userInfo:batch];
+                [self notifyForName:SEGSegmentRequestDidFailNotification object:batch userInfo:errorDict];
                 self.batchRequest = nil;
                 [self endBackgroundTask];
                 return;
@@ -405,7 +410,7 @@ NSUInteger const kSEGBackgroundTaskInvalid = 0;
 
             [self.queue removeObjectsInArray:batch];
             [self persistQueue];
-            [self notifyForName:SEGSegmentRequestDidSucceedNotification userInfo:batch];
+            [self notifyForName:SEGSegmentRequestDidSucceedNotification object:batch userInfo:errorDict];
             self.batchRequest = nil;
             [self endBackgroundTask];
         };
@@ -413,7 +418,7 @@ NSUInteger const kSEGBackgroundTaskInvalid = 0;
         [self dispatchBackground:completion];
     }];
 
-    [self notifyForName:SEGSegmentDidSendRequestNotification userInfo:batch];
+    [self notifyForName:SEGSegmentDidSendRequestNotification object:batch userInfo:nil];
 }
 
 - (void)applicationDidEnterBackground


### PR DESCRIPTION
**What does this PR do?**
Segment posts a notification if the segment request fails.
However, this notification doesn't say what the error is.
This PR relays the error information to that notification.

**Where should the reviewer start?**
Please take a look at the changes made in this function first
```
- (nullable NSURLSessionUploadTask *)upload:(NSDictionary *)batch forWriteKey:(NSString *)writeKey completionHandler:(void (^)(BOOL retry, NSError * _Nullable error))completionHandler
```
I've added `NSError * _Nullable error` to the completion handler block.

Next, please take a look at the changes made in this function:
```
- (void)sendData:(NSArray *)batch
```

**How should this be manually tested?**
Use Charles Proxy or another tool to fail the /batch request with different response statuses.

**Any background context you want to provide?**
Sometimes, we're seeing the requests fail, but don't know why. Therefore, we are trying to add some logging to find out why these requests are failing.

**What are the relevant tickets?**
-none-

**Screenshots or screencasts (if UI/UX change)**
-none-

**Questions:**
- Does the docs need an update? Yes. Someone should update how to capture these request errors.
- Are there any security concerns? No
- Do we need to update engineering / success? No
