### PR TITLE
Allow userId to be nullable on identify

### DIFF
--- a/Segment/Classes/SEGAnalytics.m
+++ b/Segment/Classes/SEGAnalytics.m
@@ -269,7 +269,7 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
 
 - (void)identify:(NSString *)userId traits:(NSDictionary *)traits options:(NSDictionary *)options
 {
-    NSCAssert2(userId.length > 0 || traits.count > 0, @"either userId (%@) or traits (%@) must be provided.", userId, traits);
+    NSCAssert2((userId != null && userId.length > 0) || traits.count > 0, @"either userId (%@) or traits (%@) must be provided.", userId, traits);
 
     // this is done here to match functionality on android where these are inserted BEFORE being spread out amongst destinations.
     // it will be set globally later when it runs through SEGIntegrationManager.identify.


### PR DESCRIPTION
**What does this PR do?**
Allow that `userId` to be null on `identify`

**How should this be manually tested?**
Call `identify` with `userId` null, like:

```objective-c
[[SEGAnalytics sharedAnalytics] identify: null traits: {"something": "other"}];
```

Fix https://github.com/segmentio/analytics-ios/issues/1024

**Screenshots or screencasts (if UI/UX change)**
On docs the `userId` is defined as optional
https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#identify
![image](https://user-images.githubusercontent.com/76348/146613888-04296918-fc7c-4dcc-b181-4deea54190d1.png)
