### PR TITLE
Enable bundled integrations if specified

### DIFF
--- a/Segment/Classes/SEGSegmentIntegration.m
+++ b/Segment/Classes/SEGSegmentIntegration.m
@@ -263,7 +263,10 @@ NSUInteger const kSEGBackgroundTaskInvalid = 0;
         if ([integration isEqualToString:kSEGSegmentDestinationName]) {
             continue;
         }
-        dict[integration] = @NO;
+        if ([dict objectForKey:integration] == nil) {
+            // Only disable the integration if it wasn't manually set.
+            dict[integration] = @NO;
+        }
     }
     return [dict copy];
 }


### PR DESCRIPTION
**What does this PR do?**
This PR fixes an issue where events wouldn't be delivered to integrations if their SDKs are bundled. Even when following the SDK [docs](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#selecting-destinations), integrations would be overridden and set to `false`. 

**How should this be manually tested?**
1. Integrate `analytics-ios` and [Braze](https://github.com/Appboy/appboy-segment-ios) into the same project. 
2. Set up Segment's `AnalyticConfiguration` to `use(SEGAppboyIntegrationFactory.instance())`
3. Track an event and set the options to allow Braze:
```swift
Analytics.shared().track("example", properties: nil, options: [
    "integrations": [
        "Appboy": true
    ]
])
```

4. Notice how the event JSON sent to the SDK has Appboy set to false, when it should actually be true.
```JSON
"integrations": {
    "Appboy": false
}
```

**What are the relevant tickets?**
Issue was reported on https://github.com/segmentio/analytics-ios/issues/967.

**Questions:**
- Does the docs need an update?
No

- Are there any security concerns?
No

- Do we need to update engineering / success?
Not sure