### PR TITLE
Include Privacy Manifest

### DIFF
--- a/Analytics.podspec
+++ b/Analytics.podspec
@@ -23,4 +23,5 @@ Pod::Spec.new do |s|
     'Segment/Classes/**/*.{h,m}',
     'Segment/Internal/**/*.{h,m}'
   ]
+  s.resources = ['Segment/PrivacyInfo.xcprivacy']
 end

--- a/Examples/CocoapodsExample/Podfile.lock
+++ b/Examples/CocoapodsExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Analytics (4.0.5)
+  - Analytics (4.1.8)
 
 DEPENDENCIES:
   - Analytics (from `../../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Analytics: ecaad22be45600b95b16849092e0548cf5a40968
+  Analytics: d8ad186a6601fc75caa5e7243b5194c3c9a28f1f
 
 PODFILE CHECKSUM: 20b258e875ed60a69591787e49bdc3ca9f7c4ad3
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.14.2

--- a/Segment/PrivacyInfo.xcprivacy
+++ b/Segment/PrivacyInfo.xcprivacy
@@ -65,10 +65,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>cdn-settings.segment.com/v1/projects/&lt;writekey&gt;/settings</string>
-		<string>https://api.segment.io/v1/b </string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
**What does this PR do?**
Even though Privacy Manifest was introduced in [#1056 ](https://github.com/segmentio/analytics-ios/pull/1056/files), Podspec was not including the file as a resource. 
I've also removed tracking domains to match with Swift's version of the library.

If merged will need to bump podspec and do a new release of the library.

**Where should the reviewer start?**
It can be tested with the `CocoapodsExample` project.

**Questions:**
- Does the docs need an update? No
- Are there any security concerns? No
- Do we need to update engineering / success? No
