### PR TITLE
No longer prompt user for local network access on app launch on macOS Sequoia

### DIFF
--- a/Segment/Internal/SEGUtils.m
+++ b/Segment/Internal/SEGUtils.m
@@ -309,7 +309,7 @@ NSDictionary *desktopSpecifications(SEGAnalyticsConfiguration *configuration, NS
         dict[@"type"] = @"macos";
         dict[@"model"] = getDeviceModel();
         dict[@"id"] = getMacUUID();
-        dict[@"name"] = [deviceInfo hostName];
+        dict[@"name"] = @"unknown";
         
         if (getAdTrackingEnabled(configuration)) {
             NSString *idfa = configuration.adSupportBlock();


### PR DESCRIPTION
**What does this PR do?**
Calling ProcessInfo.processInfo.hostName causes a new TCC prompt on macOS Sequoia for the user requesting the app be granted local network access. This code path is hit pretty often, typically during app launch. However, nothing in this framework inherently requires local network access, thus by changing the property to "unknown" instead, any app linking this framework will no longer be forced to prompt for local network access.

**Where should the reviewer start?**
Simple change

**How should this be manually tested?**
Test with an app on macOS Sequoia

**Any background context you want to provide?**
This is similar to https://github.com/segmentio/analytics-swift/pull/363

**What are the relevant tickets?**
N/A

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update? 
No

- Are there any security concerns? 
Yes without this the user is prompted with privacy dialogs unnecessarily and maybe spooked out by an app unwittingly requesting for the permission when it may not require it.

- Do we need to update engineering / success?
No