### PR TITLE
refactor: Remove unnecessary import of netinet6/in6.h

### DIFF
--- a/Segment/Classes/SEGReachability.m
+++ b/Segment/Classes/SEGReachability.m
@@ -23,7 +23,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>


### PR DESCRIPTION
**What does this PR do?**
Removed import for netinet6/in6.h as it's no longer needed. netinet/in.h already transitively includes netinet6/in6.h This fixes build error with xcode sdk 26.4
Same thing done by https://github.com/apache/cordova-plugin-network-information/pull/166

**Where should the reviewer start?**
Segment/Classes/SEGReachability.m

**How should this be manually tested?**

**Any background context you want to provide?**
I used AI and existing github issues to arrive at this solution. So an expert review would be appreciated. 

**What are the relevant tickets?**

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
- Are there any security concerns?
- Do we need to update engineering / success?
